### PR TITLE
[Workflow API] Enable participants in FederatedRuntime to review and approve plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 
 </div>
 
+**Note: The Open Federated Learning project (formerly known as OpenFL) is no longer under active development and will soon be archived. For existing users looking for ongoing support, we recommend the community transitions to Flower framework using the [migration guide](https://flower.ai/docs/framework/main/en/how-to-migrate-from-openfl.html) created in collaboration between our teams.** 
+
 Open Federated Learning (formerly known as OpenFL) is a Python framework for Federated Learning. It enables organizations to train and validate machine learning models on sensitive data. It increases privacy by allowing collaborative model training or validation across local private datasets without ever sharing that data with a central server. OpenFL is hosted by The Linux Foundation.
 
 *Looking for the Open Flash Library project also referred to as OpenFL? Find it [here](https://github.com/openfl/openfl)!*

--- a/openfl-tutorials/experimental/workflow/FederatedRuntime/101_MNIST/Portland/Portland_config.yaml
+++ b/openfl-tutorials/experimental/workflow/FederatedRuntime/101_MNIST/Portland/Portland_config.yaml
@@ -1,6 +1,7 @@
 settings:
   director_host: localhost
   director_port: 50050
+  review_experiment: True
   
 Portland:
   private_attributes: private_attributes.portland_attrs

--- a/openfl-tutorials/experimental/workflow/FederatedRuntime/101_MNIST/Seattle/Seattle_config.yaml
+++ b/openfl-tutorials/experimental/workflow/FederatedRuntime/101_MNIST/Seattle/Seattle_config.yaml
@@ -1,6 +1,7 @@
 settings:
   director_host: localhost
   director_port: 50050
+  review_experiment: True  
   
 Seattle:
   private_attributes: private_attributes.seattle_attrs

--- a/openfl-tutorials/experimental/workflow/FederatedRuntime/101_MNIST/director/director_config.yaml
+++ b/openfl-tutorials/experimental/workflow/FederatedRuntime/101_MNIST/director/director_config.yaml
@@ -2,3 +2,4 @@ settings:
   listen_host: localhost
   listen_port: 50050
   envoy_health_check_period: 5  # in seconds
+  review_experiment: True

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -9,7 +9,7 @@ import logging
 import time
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, AsyncGenerator, Dict, Iterable, Optional, Tuple, Union
+from typing import Any, AsyncGenerator, Dict, Iterable, Optional, Tuple, Union, Callable
 
 import dill
 
@@ -19,6 +19,7 @@ from openfl.experimental.workflow.component.director.experiment import (
 )
 from openfl.experimental.workflow.transport.grpc.exceptions import EnvoyNotFoundError
 from openfl.experimental.workflow.component.director.experiment import Status
+from openfl.utilities.workspace import ExperimentWorkspace
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,7 @@ class Director:
         director_config: Optional[Path] = None,
         envoy_health_check_period: int = 60,
         install_requirements: bool = True,
-        review_callback = None,  # Add review_callback parameter
+        review_callback: Optional[Callable] = None,
     ) -> None:
         """Initialize a Director object.
 
@@ -86,7 +87,7 @@ class Director:
         self.director_config = director_config
         self.install_requirements = install_requirements
         self._flow_status = asyncio.Queue()
-        self.review_callback = review_callback  # Store the review_callback
+        self.review_callback = review_callback
         self.experiments_registry = ExperimentsRegistry()
         self.col_exp = {}
         self.col_exp_queues = defaultdict(asyncio.Queue)
@@ -94,9 +95,9 @@ class Director:
         self.envoy_health_check_period = envoy_health_check_period
         # authorized_cols refers to envoy & collaborator pair (one to one mapping)
         self.authorized_cols = []
-        self.review_responses = defaultdict(dict)  # Initialize the shared dictionary as a defaultdict of dicts
-        self._director_response = asyncio.Event()
-        self.review_concensus = None
+        self.review_responses = defaultdict(dict) # Stores responses from collaborators
+        self._director_response = asyncio.Event() # Event signaling director's response
+        self.review_concensus = None # Final decision after review
 
     async def start_experiment_execution_loop(self) -> None:
         """Run tasks and experiments here"""
@@ -249,16 +250,16 @@ class Director:
         )
         # Check if review callback is enabled
         if self.review_callback:
-            review_approved = await experiment.review_experiment(self.review_callback)
+            review_approved = await self.review_experiment(experiment,self.review_callback)
             if not review_approved:
-                logger.warning(f"Experiment '{experiment_name}' was rejected? by the Director Admin.")
-                return False # Experiment rejected
+                logger.warning(f"Experiment '{experiment_name}' was rejected by the Director")
+                return False
 
         # Add the experiment to the registry
         self.authorized_cols = collaborator_names
         self.experiments_registry.add(experiment)
         logger.info(f"Experiment '{experiment_name}' was approved by Director and added to the registry.")
-        return True # Experiment approved
+        return True
 
     async def stream_experiment_stdout(
         self, experiment_name: str, caller: str
@@ -424,3 +425,28 @@ class Director:
         )
 
         return self.envoy_health_check_period
+    
+
+    async def review_experiment(self, experiment: Experiment, review_plan_callback: Callable, ) -> bool:
+        """Get plan approve in console."""
+        logger.debug("Experiment Review starts")
+        # Extract the workspace for review (without installing requirements)
+        with ExperimentWorkspace(
+            experiment.name,
+            experiment.archive_path,
+            install_requirements=False,
+            remove_archive=False,
+        ):
+            loop = asyncio.get_event_loop()
+            # Call for a review in a separate thread (server is not blocked)
+            review_approve = await loop.run_in_executor(
+                None,
+                review_plan_callback,
+                experiment.name,
+                experiment.plan_path
+            )
+            if not review_approve:
+                experiment.status = Status.REJECTED
+                experiment.archive_path.unlink(missing_ok=True)
+                return False
+        return True

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -96,38 +96,51 @@ class Director:
         # authorized_cols refers to envoy & collaborator pair (one to one mapping)
         self.authorized_cols = []
         self.review_responses = defaultdict(dict) # Stores responses from collaborators
-        self._director_response = asyncio.Event() # Event signaling director's response
-        self.review_concensus = None # Final decision after review
+        self._review_decision_event = asyncio.Event() # Event signaling director's response
+        self.review_consensus = None # Final decision after review
 
     async def start_experiment_execution_loop(self) -> None:
         """Run tasks and experiments here"""
         loop = asyncio.get_event_loop()
         while True:
             try:
-                logger.info("waiting for an exp to run")
+                logger.info("Waiting for an experiment to run...")
                 async with self.experiments_registry.get_next_experiment() as experiment:
                     await self._wait_for_authorized_envoys()
-                    # add experiment to collaborator queues so that enovys  can review the experiment
-                    # Adding the experiment to collaborators queues
+
+                    # Review Phase - Director
+                    if self.review_callback:
+                        review_approved = await experiment.review_experiment(self.review_callback)
+                    else:
+                        review_approved = True # Auto-approve if callback is not set
+
+                    # If review is not approved, update the experiment status to REJECTED
+                    if not review_approved:
+                        experiment.status = Status.REJECTED
+                        self.col_exp = dict.fromkeys(self.col_exp, None)
+                        self._review_decision_event.set() 
+                        continue
+
+                    # Review is approved Or auto approved by director add experiment to collaborators queues
                     for col_name in experiment.collaborators:
                         queue = self.col_exp_queues[col_name]
                         await queue.put(experiment.name)
 
-                    # Wait for all envoys to approve the experiment
+                    # Review Phase - Envoys
                     logger.info("Waiting for envoy reviews...")
 
-                    consensus_reached = await self.wait_for_envoys_consensus(experiment)
-                    logger.info(f"consensus_reached: {consensus_reached}")
+                    consensus_reached = await self.wait_for_all_envoy_reviews(experiment)
+                    logger.info(f"consensus_reached : {consensus_reached}")
 
+                    # If rejected by any envoy
                     if not consensus_reached:
-                        await self._process_review_rejection(experiment)
-                        continue # Skip to the next experiment if rejected
+                        await self._handle_review_rejection(experiment)
+                        # Skip to the next experiment if rejected
+                        continue 
                     
-                    self.review_concensus = True
-                    self._director_response.set()
-                    # Start the experiment
+                    # Execution Phase
+                    self.review_consensus = True 
                     logger.info(f"All participants approved - starting experiment '{experiment.name}'")
-                    
                     try:
                         run_aggregator_future = loop.create_task(
                             experiment.start(
@@ -139,10 +152,12 @@ class Director:
                                 install_requirements=False,
                             )
                         )
+                        self._review_decision_event.set() # Notify waiting parties
+
                         # Wait for the experiment to complete
                         flow_status = await run_aggregator_future
                         await self._flow_status.put(flow_status)
-                        logger.info(f" Experiment '{experiment.name}' completed successfully")
+                        logger.info(f"Experiment '{experiment.name}' completed successfully.")
 
                     except Exception as e:
                         logger.error(f" Error executing experiment '{experiment.name}': {e}")
@@ -153,29 +168,36 @@ class Director:
                 raise
             finally:
                 self._cleanup_experiment(experiment)
-                self._director_response.clear()
+                self._review_decision_event.clear()
 
     def _cleanup_experiment(self, experiment) -> None:
-        """Cleanup experiment"""
+        """Cleanup experiment resources and reset state.
+        This method is called when the experiment is completed or rejected.
+        It clears the experiment from the registry and resets the state of
+        the director.
+        It also clears the review responses and resets the review consensus
+        flag.
+        Args:
+            experiment(Experiment): The experiment to be cleaned up.
+        """#TBS
         if experiment.name in self.review_responses:
             self.review_responses.clear()
-            logger.info(f"✅ Cleared previous review responses for experiment '{experiment.name}'")
         self.col_exp = dict.fromkeys(self.col_exp, None)
-        self.review_concensus = False
+        self.review_consensus = False
 
-    async def _process_review_rejection(self, experiment)-> None:
+    async def _handle_review_rejection(self, experiment)-> None:
         """process review rejection
-        
+        this method is called when any envoy rejects the experiment.
+        It updates the experiment status to REJECTED and cleans up the experiment.
+        It also signals the director response event to notify that the review is done.
         Args:
             experiment(Experiment)
-        """
-        logger.warning(f"Experiment '{experiment.name}' rejected - skipping execution")
+        """#TBS
+        logger.info(f"Consensus not reached. Experiment '{experiment.name}' is rejected - skipping execution.")
         experiment.status = Status.REJECTED
         await self._flow_status.put((False, None))
-        logger.info(f"Experiment '{experiment.name}' marked as rejected and flow status updated.")
         self._cleanup_experiment(experiment)
-        self.review_concensus = False
-        self._director_response.set()
+        self._review_decision_event.set()
 
     async def _wait_for_authorized_envoys(self) -> None:
         """Wait until all authorized envoys are connected"""
@@ -248,17 +270,18 @@ class Director:
             users=[sender_name],
             sender=sender_name,
         )
-        # Check if review callback is enabled
-        if self.review_callback:
-            review_approved = await self.review_experiment(experiment,self.review_callback)
-            if not review_approved:
-                logger.warning(f"Experiment '{experiment_name}' was rejected by the Director")
-                return False
 
         # Add the experiment to the registry
         self.authorized_cols = collaborator_names
         self.experiments_registry.add(experiment)
-        logger.info(f"Experiment '{experiment_name}' was approved by Director and added to the registry.")
+
+        # If review is enabled, wait for review result
+        #if self.review_callback:
+        await self._review_decision_event.wait()
+        if experiment.status == Status.REJECTED:  
+            return False
+        # If review is not enabled, auto-approve the experiment
+        logger.info(f"Experiment '{experiment_name}' was Auto approved by Director and added to the registry.")
         return True
 
     async def stream_experiment_stdout(
@@ -286,11 +309,8 @@ class Director:
                 f'No experiment name "{experiment_name}" in experiments list, or caller "{caller}"'
                 f" does not have access to this experiment"
             )
-        experiment = self.experiments_registry[experiment_name]
-        while not experiment.aggregator:
-            # Check if experiment is rejected in review
-            if experiment.status == Status.REJECTED:
-                return
+        
+        while not self.experiments_registry[experiment_name].aggregator:
             await asyncio.sleep(5)
         aggregator = self.experiments_registry[experiment_name].aggregator
         while True:
@@ -303,29 +323,20 @@ class Director:
             else:
                 # Yield none if the queue is empty but the experiment is still running.
                 yield None
-    async def wait_for_envoys_consensus(self, experiment: Experiment) -> bool:
-        """
-        wait for all envoys to respond with APPROVE or  REJCT
-        Returns True if all envoys approve, False if any reject.
-        """
-        # max_wait_time = 300  # seconds (5 minutes)
-        # start_time = asyncio.get_event_loop().time()
+
+    async def wait_for_all_envoy_reviews(self, experiment: Experiment) -> bool:
+        """wait for all envoys to respond with APPROVE or  REJECT."""
         while True:
-            # If all envoys have responded
+            
             responses = self.review_responses.get(experiment.name, {})
-            logger.info("waiting for envoy responses...")
+            # Check if all envoys have responded
             if len(responses) == len(self.authorized_cols):
                 # Check if all responses are "APPROVE"
                 all_approve = all(status == "APPROVE" for status in responses.values()) 
-                logger.info("all envoys have responded")
-                logger.info(f"responses: {responses}")
+                logger.info("All envoys have responded.")
+                #logger.info(f"responses: {responses}")
                 return all_approve
             
-            
-            # --- Timeout logic commented for future iteration ---
-            # if asyncio.get_event_loop().time() - start_time > max_wait_time:
-            #     logger.warning(f"Timeout waiting for envoy consensus on experiment '{experiment.name}'")
-            #     return False
             await asyncio.sleep(1) #Waits for 1 second before the next check.
 
 
@@ -341,8 +352,8 @@ class Director:
         """
 
         self.review_responses[experiment_name][envoy_name] = review_status
-        await self._director_response.wait()
-        return self.review_concensus
+        await self._review_decision_event.wait()
+        return self.review_consensus
 
     def get_experiment_data(self, experiment_name: str) -> Path:
         """Get experiment data.
@@ -426,7 +437,7 @@ class Director:
 
         return self.envoy_health_check_period
     
-
+'''
     async def review_experiment(self, experiment: Experiment, review_plan_callback: Callable, ) -> bool:
         """Get plan approve in console."""
         logger.debug("Experiment Review starts")
@@ -450,3 +461,4 @@ class Director:
                 experiment.archive_path.unlink(missing_ok=True)
                 return False
         return True
+'''

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -155,9 +155,7 @@ class Director:
                 install_requirements=False,
             )
         )
-        # Notify waiting participants that plan is approved
-        # and experiment is started
-        experiment.review_decision_event.set()
+        # Wait for the aggregator to finish running
         flow_status = await run_aggregator_future
         await self._flow_status.put(flow_status)
         logger.info(f"Experiment '{experiment.name}' completed successfully.")
@@ -311,7 +309,7 @@ class Director:
         """
         expected_count = len(self.authorized_cols)
         while True:
-            responses = experiment.review_responses.get(experiment.name, {})
+            responses = experiment.review_responses
             if len(responses) == expected_count:
                 all_approve = all(status == "APPROVE" for status in responses.values())
                 logger.info(f"All envoys have responded for experiment '{experiment.name}'.")
@@ -332,7 +330,9 @@ class Director:
             bool: True if all envoys approve the experiment, False otherwise.
         """
         experiment = self.experiments_registry.get(experiment_name)
-        experiment.review_responses[experiment_name][envoy_name] = review_status
+        experiment.review_responses[envoy_name] = review_status
+        # Waiting here ensure that the review decision is finalized
+        # Before sending the review_consensus back to envoys.
         await experiment.review_decision_event.wait()
         return experiment.review_consensus
 

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -102,25 +102,20 @@ class Director:
         self._review_decision_event = asyncio.Event()
         self.review_consensus = None
 
-    async def start_experiment_execution_loop(self) -> None:
-        """Main loop that waits for and runs tasks and experiments here."""
-        while True:
-            try:
-                logger.info("Waiting for an experiment to run...")
-                async with self.experiments_registry.get_next_experiment() as experiment:
-                    await self._wait_for_authorized_envoys()
-                    await self._review_phase(experiment)
-                    if not self.review_consensus:
-                        continue
-                    await self._execution_phase(experiment)
+    def _cleanup_experiment(self, experiment) -> None:
+        """Reset director state and clean up experiment resources.
 
-            except Exception as e:
-                logger.error(f"Error executing experiment '{experiment.name}': {e}")
-                experiment.status = Status.FAILED
-                raise
-            finally:
-                self._cleanup_experiment(experiment)
-                self._review_decision_event.clear()
+        Clears the experiment from the registry, resets collaborator states,
+        review responses, and consensus flag.
+
+        Args:
+            experiment (Experiment): The experiment to clean up.
+        """
+        if experiment.name in self.review_responses:
+            self.review_responses.clear()
+        self.col_exp = dict.fromkeys(self.col_exp, None)
+        self.review_consensus = False
+        self._review_decision_event.set()
 
     async def _review_phase(self, experiment) -> bool:
         """Coordinates director and envoy reviews.
@@ -138,7 +133,6 @@ class Director:
 
         if review_approved:
             consensus_reached = await self._envoy_review(experiment)
-            logger.info(f"consensus_reached : {consensus_reached}")
             if not consensus_reached:
                 experiment.status = Status.REJECTED
                 logger.info(
@@ -178,26 +172,12 @@ class Director:
                 install_requirements=False,
             )
         )
-        # Notify waiting parties
+        # Notify waiting participants that plan is approved
+        # and experiment is started
         self._review_decision_event.set()
         flow_status = await run_aggregator_future
         await self._flow_status.put(flow_status)
         logger.info(f"Experiment '{experiment.name}' completed successfully.")
-
-    def _cleanup_experiment(self, experiment) -> None:
-        """Reset director state and clean up experiment resources.
-
-        Clears the experiment from the registry, resets collaborator states,
-        review responses, and consensus flag.
-
-        Args:
-            experiment (Experiment): The experiment to clean up.
-        """
-        if experiment.name in self.review_responses:
-            self.review_responses.clear()
-        self.col_exp = dict.fromkeys(self.col_exp, None)
-        self.review_consensus = False
-        self._review_decision_event.set()
 
     async def _wait_for_authorized_envoys(self) -> None:
         """Wait until all authorized envoys are connected"""
@@ -210,6 +190,25 @@ class Director:
                 "authorized envoys to connect..."
             )
             await asyncio.sleep(10)
+
+    async def start_experiment_execution_loop(self) -> None:
+        """Main loop that waits for and runs tasks and experiments here."""
+        while True:
+            try:
+                logger.info("Waiting for an experiment to run...")
+                async with self.experiments_registry.get_next_experiment() as experiment:
+                    await self._wait_for_authorized_envoys()
+                    await self._review_phase(experiment)
+                    if not self.review_consensus:
+                        continue
+                    await self._execution_phase(experiment)
+            except Exception as e:
+                logger.error(f"Error executing experiment '{experiment.name}': {e}")
+                experiment.status = Status.FAILED
+                raise
+            finally:
+                self._cleanup_experiment(experiment)
+                self._review_decision_event.clear()
 
     async def get_flow_state(self) -> Tuple[bool, bytes]:
         """Wait until the experiment flow status indicates completion

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -18,6 +18,7 @@ from openfl.experimental.workflow.component.director.experiment import (
     ExperimentsRegistry,
 )
 from openfl.experimental.workflow.transport.grpc.exceptions import EnvoyNotFoundError
+from openfl.experimental.workflow.component.director.experiment import Status
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,7 @@ class Director:
         envoy_health_check_period (int): The period for health check of envoys
             in seconds.
         authorized_cols (list): A list of authorized envoys
+        review_callback (Optional[Callable]): A callback function for reviewing experiments.
     """
 
     def __init__(
@@ -57,6 +59,7 @@ class Director:
         director_config: Optional[Path] = None,
         envoy_health_check_period: int = 60,
         install_requirements: bool = True,
+        review_callback = None,  # Add review_callback parameter
     ) -> None:
         """Initialize a Director object.
 
@@ -74,6 +77,7 @@ class Director:
             in seconds.
             install_requirements (bool, optional): A flag indicating if the
                 requirements should be installed. Defaults to True.
+            review_callback (Optional[Callable]): A callback function for reviewing experiments.
         """
         self.tls = tls
         self.root_certificate = root_certificate
@@ -82,7 +86,7 @@ class Director:
         self.director_config = director_config
         self.install_requirements = install_requirements
         self._flow_status = asyncio.Queue()
-
+        self.review_callback = review_callback  # Store the review_callback
         self.experiments_registry = ExperimentsRegistry()
         self.col_exp = {}
         self.col_exp_queues = defaultdict(asyncio.Queue)
@@ -90,6 +94,7 @@ class Director:
         self.envoy_health_check_period = envoy_health_check_period
         # authorized_cols refers to envoy & collaborator pair (one to one mapping)
         self.authorized_cols = []
+        self.review_responses = defaultdict(dict)  # Initialize the shared dictionary as a defaultdict of dicts
 
     async def start_experiment_execution_loop(self) -> None:
         """Run tasks and experiments here"""
@@ -98,23 +103,52 @@ class Director:
             try:
                 async with self.experiments_registry.get_next_experiment() as experiment:
                     await self._wait_for_authorized_envoys()
-                    run_aggregator_future = loop.create_task(
-                        experiment.start(
-                            root_certificate=self.root_certificate,
-                            certificate=self.certificate,
-                            private_key=self.private_key,
-                            tls=self.tls,
-                            director_config=self.director_config,
-                            install_requirements=self.install_requirements,
-                        )
-                    )
+                    # add experiment to collaborator queues so that enovys  can review the experiment
                     # Adding the experiment to collaborators queues
                     for col_name in experiment.collaborators:
                         queue = self.col_exp_queues[col_name]
                         await queue.put(experiment.name)
+
+                    # Wait for all envoys to approve the experiment
+                    logger.info("? Waiting for envoy reviews...")
+                    consensus_reached = await self.wait_for_envoys_consensus(experiment)
+
+                    if not consensus_reached:
+                        logger.warning(f"? Experiment '{experiment.name}' rejected - skipping execution")
+                        experiment.status = Status.REJECTED
+                        await self._flow_status.put((False, experiment))
+                        logger.info(f"Experiment '{experiment.name}' marked as rejected and flow status updated.")
+                        continue # Skip to the next experiment if rejected
+
+                    # Start the experiment
+                    logger.info(f"? All participants approved - starting experiment '{experiment.name}'")
+                    
+                    try:
+
+                        run_aggregator_future = loop.create_task(
+                            experiment.start(
+                                root_certificate=self.root_certificate,
+                                certificate=self.certificate,
+                                private_key=self.private_key,
+                                tls=self.tls,
+                                director_config=self.director_config,
+                                install_requirements=False,
+                            )
+                        )
+                        # Wait for the experiment to complete
+                        flow_status = await run_aggregator_future
+                        await self._flow_status.put(flow_status)
+                        logger.info(f"? Experiment '{experiment.name}' completed successfully")
+
+                    except Exception as e:
+                        logger.error(f"? Error executing experiment '{experiment.name}': {e}")
+                        experiment.status = Status.FAILED
+                        raise
+                    # Adding the experiment to collaborators queues
+                    #for col_name in experiment.collaborators:
+                        #queue = self.col_exp_queues[col_name]
+                        #await queue.put(experiment.name)
                     # Wait for the experiment to complete and save the result
-                    flow_status = await run_aggregator_future
-                    await self._flow_status.put(flow_status)
             except Exception as e:
                 logger.error(f"Error while executing experiment: {e}")
                 raise
@@ -172,16 +206,16 @@ class Director:
         collaborator_names: Iterable[str],
         experiment_archive_path: Path,
     ) -> bool:
-        """Set new experiment.
+        """Set new experiment and optionally review experiment .
 
         Args:
-            experiment_name (str): String id for experiment.
-            sender_name (str): The name of the sender.
-            collaborator_names (Iterable[str]): Names of collaborators.
-            experiment_archive_path (Path): Path of the experiment.
+            experiment_name (str): Identifier for the new experiment.
+            sender_name (str): Initiator of the experiment.
+            collaborator_names (Iterable[str]): Participating collaborators.
+            experiment_archive_path (Path): Path to the experiment archive.
 
         Returns:
-            bool : Boolean returned if the experiment register was successful.
+            bool: True if the experiment is accepted and registered; False otherwise.
         """
         experiment = Experiment(
             name=experiment_name,
@@ -190,10 +224,18 @@ class Director:
             users=[sender_name],
             sender=sender_name,
         )
+        # Check if review callback is enabled
+        if self.review_callback:
+            review_approved = await experiment.review_experiment(self.review_callback)
+            if not review_approved:
+                logger.warning(f"Experiment '{experiment_name}' was rejected? by the Director Admin.")
+                return False # Experiment rejected
 
+        # Add the experiment to the registry
         self.authorized_cols = collaborator_names
         self.experiments_registry.add(experiment)
-        return True
+        logger.info(f"Experiment '{experiment_name}' was approved? by Director and added to the registry.")
+        return True # Experiment approved
 
     async def stream_experiment_stdout(
         self, experiment_name: str, caller: str
@@ -233,6 +275,47 @@ class Director:
             else:
                 # Yield none if the queue is empty but the experiment is still running.
                 yield None
+    async def wait_for_envoys_consensus(self, experiment: Experiment) -> bool:
+        """
+        wait for all envoys to respond with APPROVE or any REJCT
+        Returns True if all envoys approve, False if any reject.
+        """
+        # max_wait_time = 300  # seconds (5 minutes)
+        # start_time = asyncio.get_event_loop().time()
+        while True:
+            responses = self.review_responses.get(experiment.name, {})
+            # If all envoys have responded
+            if len(responses) == len(self.authorized_cols):
+                # Check if all responses are "APPROVE"
+                all_approve = all(status == "APPROVE" for status in responses.values())
+                return all_approve
+            
+            # --- Timeout logic commented for future iteration ---
+            # if asyncio.get_event_loop().time() - start_time > max_wait_time:
+            #     logger.warning(f"? Timeout waiting for envoy consensus on experiment '{experiment.name}'")
+            #     return False
+            await asyncio.sleep(1) #Waits for 1 second before the next check.
+
+
+
+    def process_review_response(self, envoy_name: str, experiment_name: str, review_status: str) -> bool:
+        """Process a review response from an envoy. Collects review responses and checks if consensus is achieved.
+        Args:
+             envoy_name (str): The name of the envoy sending the response.
+             experiment_name (str): The name of the experiment being reviewed.
+             review_status (str): The review status ("APPROVE" or "REJECT").
+        Returns:
+            bool: True if all envoys have responded and all responses are "APPROVE", False otherwise.
+        """
+        if experiment_name not in self.review_responses:
+            self.review_responses[experiment_name] = {}
+        self.review_responses[experiment_name][envoy_name] = review_status
+
+        # Only check consensus when all responses are in
+        if len(self.review_responses[experiment_name]) == len(self.authorized_cols):
+            all_approve = all(status == "APPROVE" for status in self.review_responses[experiment_name].values())
+            return all_approve
+        return False
 
     def get_experiment_data(self, experiment_name: str) -> Path:
         """Get experiment data.

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -95,12 +95,15 @@ class Director:
         # authorized_cols refers to envoy & collaborator pair (one to one mapping)
         self.authorized_cols = []
         self.review_responses = defaultdict(dict)  # Initialize the shared dictionary as a defaultdict of dicts
+        self._director_response = asyncio.Event()
+        self.review_concensus = None
 
     async def start_experiment_execution_loop(self) -> None:
         """Run tasks and experiments here"""
         loop = asyncio.get_event_loop()
         while True:
             try:
+                logger.info("waiting for an exp to run")
                 async with self.experiments_registry.get_next_experiment() as experiment:
                     await self._wait_for_authorized_envoys()
                     # add experiment to collaborator queues so that enovys  can review the experiment
@@ -116,18 +119,15 @@ class Director:
                     logger.info(f"consensus_reached: {consensus_reached}")
 
                     if not consensus_reached:
-                        logger.warning(f"Experiment '{experiment.name}' rejected - skipping execution")
-                        experiment.status = Status.REJECTED
-                        await self._flow_status.put((False, experiment))
-                        logger.info(f"Experiment '{experiment.name}' marked as rejected and flow status updated.")
-                        
+                        await self._process_review_rejection(experiment)
                         continue # Skip to the next experiment if rejected
-
+                    
+                    self.review_concensus = True
+                    self._director_response.set()
                     # Start the experiment
                     logger.info(f"All participants approved - starting experiment '{experiment.name}'")
                     
                     try:
-
                         run_aggregator_future = loop.create_task(
                             experiment.start(
                                 root_certificate=self.root_certificate,
@@ -147,19 +147,34 @@ class Director:
                         logger.error(f" Error executing experiment '{experiment.name}': {e}")
                         experiment.status = Status.FAILED
                         raise
-                    # Adding the experiment to collaborators queues
-                    #for col_name in experiment.collaborators:
-                        #queue = self.col_exp_queues[col_name]
-                        #await queue.put(experiment.name)
-                    # Wait for the experiment to complete and save the result
             except Exception as e:
                 logger.error(f"Error while executing experiment: {e}")
                 raise
-            #finally:
-                # Always reset the review responses for this experiment
-                #if experiment.name in self.review_responses:
-                    #del self.review_responses[experiment.name]
-                    #logger.info(f"✅ Cleared previous review responses for experiment '{experiment.name}'")
+            finally:
+                self._cleanup_experiment(experiment)
+                self._director_response.clear()
+
+    def _cleanup_experiment(self, experiment) -> None:
+        """Cleanup experiment"""
+        if experiment.name in self.review_responses:
+            self.review_responses.clear()
+            logger.info(f"✅ Cleared previous review responses for experiment '{experiment.name}'")
+        self.col_exp = dict.fromkeys(self.col_exp, None)
+        self.review_concensus = False
+
+    async def _process_review_rejection(self, experiment)-> None:
+        """process review rejection
+        
+        Args:
+            experiment(Experiment)
+        """
+        logger.warning(f"Experiment '{experiment.name}' rejected - skipping execution")
+        experiment.status = Status.REJECTED
+        await self._flow_status.put((False, None))
+        logger.info(f"Experiment '{experiment.name}' marked as rejected and flow status updated.")
+        self._cleanup_experiment(experiment)
+        self.review_concensus = False
+        self._director_response.set()
 
     async def _wait_for_authorized_envoys(self) -> None:
         """Wait until all authorized envoys are connected"""
@@ -270,7 +285,11 @@ class Director:
                 f'No experiment name "{experiment_name}" in experiments list, or caller "{caller}"'
                 f" does not have access to this experiment"
             )
-        while not self.experiments_registry[experiment_name].aggregator:
+        experiment = self.experiments_registry[experiment_name]
+        while not experiment.aggregator:
+            # Check if experiment is rejected in review
+            if experiment.status == Status.REJECTED:
+                return
             await asyncio.sleep(5)
         aggregator = self.experiments_registry[experiment_name].aggregator
         while True:
@@ -291,11 +310,14 @@ class Director:
         # max_wait_time = 300  # seconds (5 minutes)
         # start_time = asyncio.get_event_loop().time()
         while True:
-            responses = self.review_responses.get(experiment.name, {})
             # If all envoys have responded
+            responses = self.review_responses.get(experiment.name, {})
+            logger.info("waiting for envoy responses...")
             if len(responses) == len(self.authorized_cols):
                 # Check if all responses are "APPROVE"
-                all_approve = all(status == "APPROVE" for status in responses.values())
+                all_approve = all(status == "APPROVE" for status in responses.values()) 
+                logger.info("all envoys have responded")
+                logger.info(f"responses: {responses}")
                 return all_approve
             
             
@@ -318,14 +340,8 @@ class Director:
         """
 
         self.review_responses[experiment_name][envoy_name] = review_status
-
-        # Only check consensus when all responses are in
-        while not len(self.review_responses[experiment_name]) == len(self.authorized_cols):
-            await asyncio.sleep(1)
-        #check if all envoys have responded 
-        all_approve = all(status == "APPROVE" for status in self.review_responses[experiment_name].values())
-        return all_approve
-        
+        await self._director_response.wait()
+        return self.review_concensus
 
     def get_experiment_data(self, experiment_name: str) -> Path:
         """Get experiment data.

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -110,18 +110,21 @@ class Director:
                         await queue.put(experiment.name)
 
                     # Wait for all envoys to approve the experiment
-                    logger.info("? Waiting for envoy reviews...")
+                    logger.info("Waiting for envoy reviews...")
+
                     consensus_reached = await self.wait_for_envoys_consensus(experiment)
+                    logger.info(f"consensus_reached: {consensus_reached}")
 
                     if not consensus_reached:
-                        logger.warning(f"? Experiment '{experiment.name}' rejected - skipping execution")
+                        logger.warning(f"Experiment '{experiment.name}' rejected - skipping execution")
                         experiment.status = Status.REJECTED
                         await self._flow_status.put((False, experiment))
                         logger.info(f"Experiment '{experiment.name}' marked as rejected and flow status updated.")
+                        
                         continue # Skip to the next experiment if rejected
 
                     # Start the experiment
-                    logger.info(f"? All participants approved - starting experiment '{experiment.name}'")
+                    logger.info(f"All participants approved - starting experiment '{experiment.name}'")
                     
                     try:
 
@@ -138,10 +141,10 @@ class Director:
                         # Wait for the experiment to complete
                         flow_status = await run_aggregator_future
                         await self._flow_status.put(flow_status)
-                        logger.info(f"? Experiment '{experiment.name}' completed successfully")
+                        logger.info(f" Experiment '{experiment.name}' completed successfully")
 
                     except Exception as e:
-                        logger.error(f"? Error executing experiment '{experiment.name}': {e}")
+                        logger.error(f" Error executing experiment '{experiment.name}': {e}")
                         experiment.status = Status.FAILED
                         raise
                     # Adding the experiment to collaborators queues
@@ -152,6 +155,11 @@ class Director:
             except Exception as e:
                 logger.error(f"Error while executing experiment: {e}")
                 raise
+            #finally:
+                # Always reset the review responses for this experiment
+                #if experiment.name in self.review_responses:
+                    #del self.review_responses[experiment.name]
+                    #logger.info(f"✅ Cleared previous review responses for experiment '{experiment.name}'")
 
     async def _wait_for_authorized_envoys(self) -> None:
         """Wait until all authorized envoys are connected"""
@@ -234,7 +242,7 @@ class Director:
         # Add the experiment to the registry
         self.authorized_cols = collaborator_names
         self.experiments_registry.add(experiment)
-        logger.info(f"Experiment '{experiment_name}' was approved? by Director and added to the registry.")
+        logger.info(f"Experiment '{experiment_name}' was approved by Director and added to the registry.")
         return True # Experiment approved
 
     async def stream_experiment_stdout(
@@ -277,7 +285,7 @@ class Director:
                 yield None
     async def wait_for_envoys_consensus(self, experiment: Experiment) -> bool:
         """
-        wait for all envoys to respond with APPROVE or any REJCT
+        wait for all envoys to respond with APPROVE or  REJCT
         Returns True if all envoys approve, False if any reject.
         """
         # max_wait_time = 300  # seconds (5 minutes)
@@ -290,15 +298,16 @@ class Director:
                 all_approve = all(status == "APPROVE" for status in responses.values())
                 return all_approve
             
+            
             # --- Timeout logic commented for future iteration ---
             # if asyncio.get_event_loop().time() - start_time > max_wait_time:
-            #     logger.warning(f"? Timeout waiting for envoy consensus on experiment '{experiment.name}'")
+            #     logger.warning(f"Timeout waiting for envoy consensus on experiment '{experiment.name}'")
             #     return False
             await asyncio.sleep(1) #Waits for 1 second before the next check.
 
 
 
-    def process_review_response(self, envoy_name: str, experiment_name: str, review_status: str) -> bool:
+    async def process_review_response(self, envoy_name: str, experiment_name: str, review_status: str) -> bool:
         """Process a review response from an envoy. Collects review responses and checks if consensus is achieved.
         Args:
              envoy_name (str): The name of the envoy sending the response.
@@ -307,15 +316,16 @@ class Director:
         Returns:
             bool: True if all envoys have responded and all responses are "APPROVE", False otherwise.
         """
-        if experiment_name not in self.review_responses:
-            self.review_responses[experiment_name] = {}
+
         self.review_responses[experiment_name][envoy_name] = review_status
 
         # Only check consensus when all responses are in
-        if len(self.review_responses[experiment_name]) == len(self.authorized_cols):
-            all_approve = all(status == "APPROVE" for status in self.review_responses[experiment_name].values())
-            return all_approve
-        return False
+        while not len(self.review_responses[experiment_name]) == len(self.authorized_cols):
+            await asyncio.sleep(1)
+        #check if all envoys have responded 
+        all_approve = all(status == "APPROVE" for status in self.review_responses[experiment_name].values())
+        return all_approve
+        
 
     def get_experiment_data(self, experiment_name: str) -> Path:
         """Get experiment data.

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -9,17 +9,16 @@ import logging
 import time
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, AsyncGenerator, Dict, Iterable, Optional, Tuple, Union, Callable
+from typing import Any, AsyncGenerator, Callable, Dict, Iterable, Optional, Tuple, Union
 
 import dill
 
 from openfl.experimental.workflow.component.director.experiment import (
     Experiment,
     ExperimentsRegistry,
+    Status,
 )
 from openfl.experimental.workflow.transport.grpc.exceptions import EnvoyNotFoundError
-from openfl.experimental.workflow.component.director.experiment import Status
-from openfl.utilities.workspace import ExperimentWorkspace
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +47,11 @@ class Director:
             in seconds.
         authorized_cols (list): A list of authorized envoys
         review_callback (Optional[Callable]): A callback function for reviewing experiments.
+        review_responses (defaultdict): A dictionary to store review responses
+            from envoys.
+        _review_decision_event (asyncio.Event): An event to signal the review decision.
+        review_consensus (Optional[bool]): A flag indicating if the review consensus
+            is reached.
     """
 
     def __init__(
@@ -94,9 +98,9 @@ class Director:
         self.envoy_health_check_period = envoy_health_check_period
         # authorized_cols refers to envoy & collaborator pair (one to one mapping)
         self.authorized_cols = []
-        self.review_responses = defaultdict(dict) # Stores responses from collaborators
-        self._review_decision_event = asyncio.Event() # Event signaling director's response
-        self.review_consensus = None # Final decision after review
+        self.review_responses = defaultdict(dict)
+        self._review_decision_event = asyncio.Event()
+        self.review_consensus = None
 
     async def start_experiment_execution_loop(self) -> None:
         """Main loop that waits for and runs tasks and experiments here."""
@@ -105,12 +109,9 @@ class Director:
                 logger.info("Waiting for an experiment to run...")
                 async with self.experiments_registry.get_next_experiment() as experiment:
                     await self._wait_for_authorized_envoys()
-
-                    # Phase 1: Review (Director + Envoy)
-                    if not await self._review_phase(experiment): # Need more clarity here just check 
-                        continue  # Review failed, skip to next experiment
-
-                    # Phase 2: Execution 
+                    await self._review_phase(experiment)
+                    if not self.review_consensus:
+                        continue
                     await self._execution_phase(experiment)
 
             except Exception as e:
@@ -121,36 +122,45 @@ class Director:
                 self._cleanup_experiment(experiment)
                 self._review_decision_event.clear()
 
-    #----------------------- PHASE 1: REVIEW -----------------------------
-
     async def _review_phase(self, experiment) -> bool:
-        """Handles both Director and Envoy review phases."""# update docstring
-        # Director Review
-        review_approved = await experiment.review_experiment( # check if await can be remv
-            self.review_callback
-        ) if self.review_callback else True
+        """Coordinates director and envoy reviews.
 
-        if not review_approved:
+        Args:
+            experiment (Experiment): The experiment to be reviewed.
+
+        Returns:
+            bool: True if the review consensus is reached, False otherwise.
+        """
+        review_approved = consensus_reached = True
+        if self.review_callback:
+            # Director review
+            review_approved = experiment.review_experiment(self.review_callback)
+
+        if review_approved:
+            consensus_reached = await self._envoy_review(experiment)
+            logger.info(f"consensus_reached : {consensus_reached}")
+            if not consensus_reached:
+                await self._handle_review_rejection(experiment)
+        else:
             experiment.status = Status.REJECTED
             self._review_decision_event.set()
-            return False
-        
-        # Notify envoys about the experiment
+
+        self.review_consensus = review_approved and consensus_reached
+
+    async def _envoy_review(self, experiment) -> bool:
+        """Notifies envoys and waits for their consensus.
+
+        Args:
+            experiment (Experiment): The experiment to be reviewed.
+
+        Returns:
+            bool: True if all envoys approve the experiment, False otherwise.
+        """
         for col_name in experiment.collaborators:
             await self.col_exp_queues[col_name].put(experiment.name)
-        
-        # Wait for envoy reviews
+
         logger.info("Waiting for envoy reviews...")
-        consensus_reached = await self.wait_for_all_envoy_reviews(experiment)
-        logger.info(f"consensus_reached : {consensus_reached}")
-        if not consensus_reached:
-            await self._handle_review_rejection(experiment)
-            return False
-        
-        self.review_consensus = True
-        return True
-    
-    # ------------------------ PHASE 2: EXECUTION ------------------------
+        return await self.wait_for_all_envoy_reviews(experiment)
 
     async def _execution_phase(self, experiment) -> None:
         """Handles the execution phase of the experiment."""
@@ -166,43 +176,39 @@ class Director:
                 install_requirements=False,
             )
         )
-
-        self._review_decision_event.set()  # Notify waiting parties
-
-        # Wait for the experiment to complete
+        # Notify waiting parties
+        self._review_decision_event.set()
         flow_status = await run_aggregator_future
         await self._flow_status.put(flow_status)
         logger.info(f"Experiment '{experiment.name}' completed successfully.")
 
-    # ---------------------- CLEANUP AND REJECTION -----------------------
-
     def _cleanup_experiment(self, experiment) -> None:
-        """Cleanup experiment resources and reset state.
-        This method is called when the experiment is completed or rejected.
-        It clears the experiment from the registry and resets the state of
-        the director.
-        It also clears the review responses and resets the review consensus
-        flag.
+        """Reset director state and clean up experiment resources.
+
+        Clears the experiment from the registry, resets collaborator states,
+        review responses, and consensus flag.
+
         Args:
-            experiment(Experiment): The experiment to be cleaned up.
-        """#TBS
+            experiment (Experiment): The experiment to clean up.
+        """
         if experiment.name in self.review_responses:
             self.review_responses.clear()
         self.col_exp = dict.fromkeys(self.col_exp, None)
         self.review_consensus = False
 
-    async def _handle_review_rejection(self, experiment)-> None:
-        """process review rejection
-        this method is called when any envoy rejects the experiment.
-        It updates the experiment status to REJECTED and cleans up the experiment.
-        It also signals the director response event to notify that the review is done.
+    async def _handle_review_rejection(self, experiment) -> None:
+        """Handle experiment rejection.
+
+        Marks experiment as REJECTED, cleans up resources, and signals review completion.
+
         Args:
-            experiment(Experiment)
-        """#TBS
-        logger.info(f"Consensus not reached. Experiment '{experiment.name}' is rejected - skipping execution.")
+            experiment (Experiment): The rejected experiment.
+        """
+        logger.info(
+            f"Consensus not reached. Experiment '{experiment.name}is rejected - skipping execution."
+        )
         experiment.status = Status.REJECTED
-        await self._flow_status.put((False, None))# need to check if it can be removed or not 
-        self._cleanup_experiment(experiment) #called at multiple time 
+        self._cleanup_experiment(experiment)  # called at multiple time
         self._review_decision_event.set()
 
     async def _wait_for_authorized_envoys(self) -> None:
@@ -281,13 +287,13 @@ class Director:
         self.authorized_cols = collaborator_names
         self.experiments_registry.add(experiment)
 
-        # If review is enabled, wait for review result
-        #if self.review_callback:
         await self._review_decision_event.wait()
-        if experiment.status == Status.REJECTED:  
+        if experiment.status == Status.REJECTED:
             return False
-        # If review is not enabled, auto-approve the experiment
-        logger.info(f"Experiment '{experiment_name}' was Auto approved by Director and added to the registry.")
+        logger.info(
+            f"Experiment '{experiment_name}' was Auto approved by Director "
+            "and added to the registry."
+        )
         return True
 
     async def stream_experiment_stdout(
@@ -315,7 +321,7 @@ class Director:
                 f'No experiment name "{experiment_name}" in experiments list, or caller "{caller}"'
                 f" does not have access to this experiment"
             )
-        
+
         while not self.experiments_registry[experiment_name].aggregator:
             await asyncio.sleep(5)
         aggregator = self.experiments_registry[experiment_name].aggregator
@@ -331,32 +337,35 @@ class Director:
                 yield None
 
     async def wait_for_all_envoy_reviews(self, experiment: Experiment) -> bool:
-        """wait for all envoys to respond with APPROVE or  REJECT."""
-        while True:
-            
-            responses = self.review_responses.get(experiment.name, {})
-            # Check if all envoys have responded
-            if len(responses) == len(self.authorized_cols):
-                # Check if all responses are "APPROVE"
-                all_approve = all(status == "APPROVE" for status in responses.values()) 
-                logger.info("All envoys have responded.")
-                #logger.info(f"responses: {responses}")
-                return all_approve
-            
-            await asyncio.sleep(1) #Waits for 1 second before the next check.
+        """Wait for all envoys to respond with APPROVE or REJECT.
 
-
-
-    async def process_review_response(self, envoy_name: str, experiment_name: str, review_status: str) -> bool:
-        """Process a review response from an envoy. Collects review responses and checks if consensus is achieved.
         Args:
-             envoy_name (str): The name of the envoy sending the response.
-             experiment_name (str): The name of the experiment being reviewed.
-             review_status (str): The review status ("APPROVE" or "REJECT").
+            experiment (Experiment): The experiment being reviewed.
         Returns:
-            bool: True if all envoys have responded and all responses are "APPROVE", False otherwise.
+            bool: True if all envoys approve the experiment, False otherwise.
         """
+        expected_count = len(self.authorized_cols)
+        while True:
+            responses = self.review_responses.get(experiment.name, {})
+            if len(responses) == expected_count:
+                all_approve = all(status == "APPROVE" for status in responses.values())
+                logger.info(f"All envoys have responded for experiment '{experiment.name}'.")
+                return all_approve
 
+            await asyncio.sleep(1)  # Waits for 1 second before the next check.
+
+    async def process_review_response(
+        self, envoy_name: str, experiment_name: str, review_status: str
+    ) -> bool:
+        """Process a review response from an envoy. Collects review responses and
+            check if consensus is achieved.
+        Args:
+             envoy_name (str): Envoy sending the response.
+             experiment_name (str): The name of the experiment being reviewed.
+             review_status (str): "APPROVE" or "REJECT".
+        Returns:
+            bool: True if all envoys approve the experiment, False otherwise.
+        """
         self.review_responses[experiment_name][envoy_name] = review_status
         await self._review_decision_event.wait()
         return self.review_consensus
@@ -442,29 +451,3 @@ class Director:
         )
 
         return self.envoy_health_check_period
-    
-'''
-    async def review_experiment(self, experiment: Experiment, review_plan_callback: Callable, ) -> bool:
-        """Get plan approve in console."""
-        logger.debug("Experiment Review starts")
-        # Extract the workspace for review (without installing requirements)
-        with ExperimentWorkspace(
-            experiment.name,
-            experiment.archive_path,
-            install_requirements=False,
-            remove_archive=False,
-        ):
-            loop = asyncio.get_event_loop()
-            # Call for a review in a separate thread (server is not blocked)
-            review_approve = await loop.run_in_executor(
-                None,
-                review_plan_callback,
-                experiment.name,
-                experiment.plan_path
-            )
-            if not review_approve:
-                experiment.status = Status.REJECTED
-                experiment.archive_path.unlink(missing_ok=True)
-                return False
-        return True
-'''

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -42,11 +42,11 @@ class Director:
             collaborators.
         col_exp_queues (defaultdict): A defaultdict to store the experiment
             queues for collaborators.
-        _envoy_registry (dict): A dcitionary to store envoy info
+        _envoy_registry (dict): A dictionary to store envoy info
         envoy_health_check_period (int): The period for health check of envoys
             in seconds.
         authorized_cols (list): A list of authorized envoys
-        review_callback (Optional[Callable]): A callback function for reviewing experiments.
+        
     """
 
     def __init__(
@@ -77,6 +77,8 @@ class Director:
             in seconds.
             install_requirements (bool, optional): A flag indicating if the
                 requirements should be installed. Defaults to True.
+            review_callback (Optional[Callable]): A callback function for
+                reviewing experiments. Defaults to None.
         """
         self.tls = tls
         self.root_certificate = root_certificate
@@ -113,22 +115,22 @@ class Director:
         Args:
             experiment (Experiment): The experiment to be reviewed.
         """
-        review_approved = True
+        is_approved  = True
         if self.review_callback:
             # Director review
-            review_approved = experiment.review_experiment(self.review_callback)
+            is_approved  = experiment.review_experiment(self.review_callback)
 
         # Add director review to review_details
-        experiment.record_review("Director", review_approved)
+        experiment.record_review("Director", is_approved )
 
-        if review_approved:
-            review_approved = await self._envoy_review(experiment)
-            if not review_approved:
+        if is_approved :
+            is_approved  = await self._envoy_review(experiment)
+            if not is_approved :
                 logger.info(
                     f"Consensus not reached. Experiment '{experiment.name} "
                     "is rejected - skipping execution."
                 )
-        experiment.review_consensus = review_approved
+        experiment.review_consensus = is_approved 
 
     async def _envoy_review(self, experiment) -> bool:
         """Notifies envoys and waits for their consensus.
@@ -146,7 +148,11 @@ class Director:
         return await self.wait_for_all_envoy_reviews(experiment)
 
     async def _execution_phase(self, experiment) -> None:
-        """Handles the execution phase of the experiment."""
+        """Starts the experiment and waits for its execution to complete.
+
+        Args:
+            experiment (Experiment): The experiment to be reviewed.
+        """
         loop = asyncio.get_event_loop()
         run_aggregator_future = loop.create_task(
             experiment.start(
@@ -189,7 +195,6 @@ class Director:
                     await self._execution_phase(experiment)
             except Exception as e:
                 logger.error(f"Error executing experiment '{experiment.name}': {e}")
-                experiment.status = Status.FAILED
                 raise
             finally:
                 self._cleanup_experiment(experiment)
@@ -235,7 +240,7 @@ class Director:
         collaborator_names: Iterable[str],
         experiment_archive_path: Path,
     ) -> bool:
-        """Set new experiment and optionally review experiment .
+        """Set new experiment and optionally review experiment.
 
         Args:
             experiment_name (str): Identifier for the new experiment.

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -47,11 +47,6 @@ class Director:
             in seconds.
         authorized_cols (list): A list of authorized envoys
         review_callback (Optional[Callable]): A callback function for reviewing experiments.
-        review_responses (defaultdict): A dictionary to store review responses
-            from envoys.
-        _review_decision_event (asyncio.Event): An event to signal the review decision.
-        review_consensus (Optional[bool]): A flag indicating if the review consensus
-            is reached.
     """
 
     def __init__(
@@ -98,9 +93,6 @@ class Director:
         self.envoy_health_check_period = envoy_health_check_period
         # authorized_cols refers to envoy & collaborator pair (one to one mapping)
         self.authorized_cols = []
-        self.review_responses = defaultdict(dict)
-        self._review_decision_event = asyncio.Event()
-        self.review_consensus = None
 
     def _cleanup_experiment(self, experiment) -> None:
         """Reset director state and clean up experiment resources.
@@ -111,12 +103,9 @@ class Director:
         Args:
             experiment (Experiment): The experiment to clean up.
         """
-        if experiment.name in self.review_responses:
-            self.review_responses.clear()
         self.col_exp = dict.fromkeys(self.col_exp, None)
-        self.review_consensus = False
-        if not self._review_decision_event.is_set():
-            self._review_decision_event.set()
+        if not experiment.review_decision_event.is_set():
+            experiment.review_decision_event.set()
 
     async def _review_phase(self, experiment) -> None:
         """Coordinates director and envoy reviews.
@@ -136,7 +125,7 @@ class Director:
                     f"Consensus not reached. Experiment '{experiment.name} "
                     "is rejected - skipping execution."
                 )
-        self.review_consensus = review_approved
+        experiment.review_consensus = review_approved
 
     async def _envoy_review(self, experiment) -> bool:
         """Notifies envoys and waits for their consensus.
@@ -168,7 +157,7 @@ class Director:
         )
         # Notify waiting participants that plan is approved
         # and experiment is started
-        self._review_decision_event.set()
+        experiment.review_decision_event.set()
         flow_status = await run_aggregator_future
         await self._flow_status.put(flow_status)
         logger.info(f"Experiment '{experiment.name}' completed successfully.")
@@ -193,7 +182,7 @@ class Director:
                 async with self.experiments_registry.get_next_experiment() as experiment:
                     await self._wait_for_authorized_envoys()
                     await self._review_phase(experiment)
-                    if not self.review_consensus:
+                    if not experiment.review_consensus:
                         experiment.status = Status.REJECTED
                         continue
                     await self._execution_phase(experiment)
@@ -203,7 +192,6 @@ class Director:
                 raise
             finally:
                 self._cleanup_experiment(experiment)
-                self._review_decision_event.clear()
 
     async def get_flow_state(self) -> Tuple[bool, bytes]:
         """Wait until the experiment flow status indicates completion
@@ -270,7 +258,7 @@ class Director:
         self.experiments_registry.add(experiment)
 
         # Waiting for experiment review plan decision
-        await self._review_decision_event.wait()
+        await experiment.review_decision_event.wait()
         return experiment.status != Status.REJECTED
 
     async def stream_experiment_stdout(
@@ -323,7 +311,7 @@ class Director:
         """
         expected_count = len(self.authorized_cols)
         while True:
-            responses = self.review_responses.get(experiment.name, {})
+            responses = experiment.review_responses.get(experiment.name, {})
             if len(responses) == expected_count:
                 all_approve = all(status == "APPROVE" for status in responses.values())
                 logger.info(f"All envoys have responded for experiment '{experiment.name}'.")
@@ -343,9 +331,10 @@ class Director:
         Returns:
             bool: True if all envoys approve the experiment, False otherwise.
         """
-        self.review_responses[experiment_name][envoy_name] = review_status
-        await self._review_decision_event.wait()
-        return self.review_consensus
+        experiment = self.experiments_registry.get(experiment_name)
+        experiment.review_responses[experiment_name][envoy_name] = review_status
+        await experiment.review_decision_event.wait()
+        return experiment.review_consensus
 
     def get_experiment_data(self, experiment_name: str) -> Path:
         """Get experiment data.

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -78,7 +78,6 @@ class Director:
             in seconds.
             install_requirements (bool, optional): A flag indicating if the
                 requirements should be installed. Defaults to True.
-            review_callback (Optional[Callable]): A callback function for reviewing experiments.
         """
         self.tls = tls
         self.root_certificate = root_certificate
@@ -100,75 +99,82 @@ class Director:
         self.review_consensus = None # Final decision after review
 
     async def start_experiment_execution_loop(self) -> None:
-        """Run tasks and experiments here"""
-        loop = asyncio.get_event_loop()
+        """Main loop that waits for and runs tasks and experiments here."""
         while True:
             try:
                 logger.info("Waiting for an experiment to run...")
                 async with self.experiments_registry.get_next_experiment() as experiment:
                     await self._wait_for_authorized_envoys()
 
-                    # Review Phase - Director
-                    if self.review_callback:
-                        review_approved = await experiment.review_experiment(self.review_callback)
-                    else:
-                        review_approved = True # Auto-approve if callback is not set
+                    # Phase 1: Review (Director + Envoy)
+                    if not await self._review_phase(experiment): # Need more clarity here just check 
+                        continue  # Review failed, skip to next experiment
 
-                    # If review is not approved, update the experiment status to REJECTED
-                    if not review_approved:
-                        experiment.status = Status.REJECTED
-                        self.col_exp = dict.fromkeys(self.col_exp, None)
-                        self._review_decision_event.set() 
-                        continue
+                    # Phase 2: Execution 
+                    await self._execution_phase(experiment)
 
-                    # Review is approved Or auto approved by director add experiment to collaborators queues
-                    for col_name in experiment.collaborators:
-                        queue = self.col_exp_queues[col_name]
-                        await queue.put(experiment.name)
-
-                    # Review Phase - Envoys
-                    logger.info("Waiting for envoy reviews...")
-
-                    consensus_reached = await self.wait_for_all_envoy_reviews(experiment)
-                    logger.info(f"consensus_reached : {consensus_reached}")
-
-                    # If rejected by any envoy
-                    if not consensus_reached:
-                        await self._handle_review_rejection(experiment)
-                        # Skip to the next experiment if rejected
-                        continue 
-                    
-                    # Execution Phase
-                    self.review_consensus = True 
-                    logger.info(f"All participants approved - starting experiment '{experiment.name}'")
-                    try:
-                        run_aggregator_future = loop.create_task(
-                            experiment.start(
-                                root_certificate=self.root_certificate,
-                                certificate=self.certificate,
-                                private_key=self.private_key,
-                                tls=self.tls,
-                                director_config=self.director_config,
-                                install_requirements=False,
-                            )
-                        )
-                        self._review_decision_event.set() # Notify waiting parties
-
-                        # Wait for the experiment to complete
-                        flow_status = await run_aggregator_future
-                        await self._flow_status.put(flow_status)
-                        logger.info(f"Experiment '{experiment.name}' completed successfully.")
-
-                    except Exception as e:
-                        logger.error(f" Error executing experiment '{experiment.name}': {e}")
-                        experiment.status = Status.FAILED
-                        raise
             except Exception as e:
-                logger.error(f"Error while executing experiment: {e}")
+                logger.error(f"Error executing experiment '{experiment.name}': {e}")
+                experiment.status = Status.FAILED
                 raise
             finally:
                 self._cleanup_experiment(experiment)
                 self._review_decision_event.clear()
+
+    #----------------------- PHASE 1: REVIEW -----------------------------
+
+    async def _review_phase(self, experiment) -> bool:
+        """Handles both Director and Envoy review phases."""# update docstring
+        # Director Review
+        review_approved = await experiment.review_experiment( # check if await can be remv
+            self.review_callback
+        ) if self.review_callback else True
+
+        if not review_approved:
+            experiment.status = Status.REJECTED
+            self._review_decision_event.set()
+            return False
+        
+        # Notify envoys about the experiment
+        for col_name in experiment.collaborators:
+            await self.col_exp_queues[col_name].put(experiment.name)
+        
+        # Wait for envoy reviews
+        logger.info("Waiting for envoy reviews...")
+        consensus_reached = await self.wait_for_all_envoy_reviews(experiment)
+        logger.info(f"consensus_reached : {consensus_reached}")
+        if not consensus_reached:
+            await self._handle_review_rejection(experiment)
+            return False
+        
+        self.review_consensus = True
+        return True
+    
+    # ------------------------ PHASE 2: EXECUTION ------------------------
+
+    async def _execution_phase(self, experiment) -> None:
+        """Handles the execution phase of the experiment."""
+        loop = asyncio.get_event_loop()
+        logger.info(f"All participants approved - starting experiment '{experiment.name}'")
+        run_aggregator_future = loop.create_task(
+            experiment.start(
+                root_certificate=self.root_certificate,
+                certificate=self.certificate,
+                private_key=self.private_key,
+                tls=self.tls,
+                director_config=self.director_config,
+                install_requirements=False,
+            )
+        )
+
+        self._review_decision_event.set()  # Notify waiting parties
+
+        # Wait for the experiment to complete
+        flow_status = await run_aggregator_future
+        await self._flow_status.put(flow_status)
+        logger.info(f"Experiment '{experiment.name}' completed successfully.")
+
+    # ---------------------- CLEANUP AND REJECTION -----------------------
 
     def _cleanup_experiment(self, experiment) -> None:
         """Cleanup experiment resources and reset state.
@@ -195,8 +201,8 @@ class Director:
         """#TBS
         logger.info(f"Consensus not reached. Experiment '{experiment.name}' is rejected - skipping execution.")
         experiment.status = Status.REJECTED
-        await self._flow_status.put((False, None))
-        self._cleanup_experiment(experiment)
+        await self._flow_status.put((False, None))# need to check if it can be removed or not 
+        self._cleanup_experiment(experiment) #called at multiple time 
         self._review_decision_event.set()
 
     async def _wait_for_authorized_envoys(self) -> None:

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -8,7 +8,6 @@ import asyncio
 import logging
 import time
 from collections import defaultdict
-from datetime import datetime,timezone
 from pathlib import Path
 from typing import Any, AsyncGenerator, Callable, Dict, Iterable, Optional, Tuple, Union
 
@@ -120,11 +119,8 @@ class Director:
             review_approved = experiment.review_experiment(self.review_callback)
 
         # Add director review to review_details
-        experiment.review_details["director"].append({
-            'reviewer_name': 'Director',
-            'decision': "APPROVED" if review_approved else "REJECTED",
-            'timestamp': datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-        })
+        experiment.record_review("Director", review_approved)
+
         if review_approved:
             review_approved = await self._envoy_review(experiment)
             if not review_approved:
@@ -338,11 +334,7 @@ class Director:
         """
         experiment = self.experiments_registry.get(experiment_name)
         experiment.review_responses[envoy_name] = review_status
-        experiment.review_details[envoy_name].append({
-            'reviewer_name': envoy_name,
-            'decision': "APPROVED" if review_status == "APPROVE" else "REJECTED",
-            'timestamp': datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-        })
+        experiment.record_review(envoy_name, review_status == "APPROVE")
         # Waiting here ensure that the review decision is finalized
         # Before sending the review_consensus back to envoys.
         await experiment.review_decision_event.wait()

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -7,8 +7,8 @@
 import asyncio
 import logging
 import time
-from datetime import datetime,timezone
 from collections import defaultdict
+from datetime import datetime,timezone
 from pathlib import Path
 from typing import Any, AsyncGenerator, Callable, Dict, Iterable, Optional, Tuple, Union
 

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -115,33 +115,28 @@ class Director:
             self.review_responses.clear()
         self.col_exp = dict.fromkeys(self.col_exp, None)
         self.review_consensus = False
-        self._review_decision_event.set()
+        if not self._review_decision_event.is_set():
+            self._review_decision_event.set()
 
-    async def _review_phase(self, experiment) -> bool:
+    async def _review_phase(self, experiment) -> None:
         """Coordinates director and envoy reviews.
 
         Args:
             experiment (Experiment): The experiment to be reviewed.
-
-        Returns:
-            bool: True if the review consensus is reached, False otherwise.
         """
-        review_approved = consensus_reached = True
+        review_approved = True
         if self.review_callback:
             # Director review
             review_approved = experiment.review_experiment(self.review_callback)
 
         if review_approved:
-            consensus_reached = await self._envoy_review(experiment)
-            if not consensus_reached:
-                experiment.status = Status.REJECTED
+            review_approved = await self._envoy_review(experiment)
+            if not review_approved:
                 logger.info(
                     f"Consensus not reached. Experiment '{experiment.name} "
                     "is rejected - skipping execution."
                 )
-        else:
-            experiment.status = Status.REJECTED
-        self.review_consensus = review_approved and consensus_reached
+        self.review_consensus = review_approved
 
     async def _envoy_review(self, experiment) -> bool:
         """Notifies envoys and waits for their consensus.
@@ -199,6 +194,7 @@ class Director:
                     await self._wait_for_authorized_envoys()
                     await self._review_phase(experiment)
                     if not self.review_consensus:
+                        experiment.status = Status.REJECTED
                         continue
                     await self._execution_phase(experiment)
             except Exception as e:

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -161,7 +161,6 @@ class Director:
     async def _execution_phase(self, experiment) -> None:
         """Handles the execution phase of the experiment."""
         loop = asyncio.get_event_loop()
-        logger.info(f"All participants approved - starting experiment '{experiment.name}'")
         run_aggregator_future = loop.create_task(
             experiment.start(
                 root_certificate=self.root_certificate,
@@ -274,14 +273,9 @@ class Director:
         self.authorized_cols = collaborator_names
         self.experiments_registry.add(experiment)
 
+        # Waiting for experiment review plan decision
         await self._review_decision_event.wait()
-        if experiment.status == Status.REJECTED:
-            return False
-        logger.info(
-            f"Experiment '{experiment_name}' was Auto approved by Director "
-            "and added to the registry."
-        )
-        return True
+        return experiment.status != Status.REJECTED
 
     async def stream_experiment_stdout(
         self, experiment_name: str, caller: str

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -7,6 +7,7 @@
 import asyncio
 import logging
 import time
+from datetime import datetime,timezone
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, AsyncGenerator, Callable, Dict, Iterable, Optional, Tuple, Union
@@ -118,6 +119,12 @@ class Director:
             # Director review
             review_approved = experiment.review_experiment(self.review_callback)
 
+        # Add director review to review_details
+        experiment.review_details["director"].append({
+            'reviewer_name': 'Director',
+            'decision': "APPROVED" if review_approved else "REJECTED",
+            'timestamp': datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        })
         if review_approved:
             review_approved = await self._envoy_review(experiment)
             if not review_approved:
@@ -331,6 +338,11 @@ class Director:
         """
         experiment = self.experiments_registry.get(experiment_name)
         experiment.review_responses[envoy_name] = review_status
+        experiment.review_details[envoy_name].append({
+            'reviewer_name': envoy_name,
+            'decision': "APPROVED" if review_status == "APPROVE" else "REJECTED",
+            'timestamp': datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        })
         # Waiting here ensure that the review decision is finalized
         # Before sending the review_consensus back to envoys.
         await experiment.review_decision_event.wait()

--- a/openfl/experimental/workflow/component/director/director.py
+++ b/openfl/experimental/workflow/component/director/director.py
@@ -140,11 +140,13 @@ class Director:
             consensus_reached = await self._envoy_review(experiment)
             logger.info(f"consensus_reached : {consensus_reached}")
             if not consensus_reached:
-                await self._handle_review_rejection(experiment)
+                experiment.status = Status.REJECTED
+                logger.info(
+                    f"Consensus not reached. Experiment '{experiment.name} "
+                    "is rejected - skipping execution."
+                )
         else:
             experiment.status = Status.REJECTED
-            self._review_decision_event.set()
-
         self.review_consensus = review_approved and consensus_reached
 
     async def _envoy_review(self, experiment) -> bool:
@@ -195,20 +197,6 @@ class Director:
             self.review_responses.clear()
         self.col_exp = dict.fromkeys(self.col_exp, None)
         self.review_consensus = False
-
-    async def _handle_review_rejection(self, experiment) -> None:
-        """Handle experiment rejection.
-
-        Marks experiment as REJECTED, cleans up resources, and signals review completion.
-
-        Args:
-            experiment (Experiment): The rejected experiment.
-        """
-        logger.info(
-            f"Consensus not reached. Experiment '{experiment.name}is rejected - skipping execution."
-        )
-        experiment.status = Status.REJECTED
-        self._cleanup_experiment(experiment)  # called at multiple time
         self._review_decision_event.set()
 
     async def _wait_for_authorized_envoys(self) -> None:

--- a/openfl/experimental/workflow/component/director/experiment.py
+++ b/openfl/experimental/workflow/component/director/experiment.py
@@ -9,7 +9,7 @@ import logging
 from contextlib import asynccontextmanager
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Iterable, List, Optional, Tuple, Union, Callable
+from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
 
 from openfl.experimental.workflow.federated import Plan
 from openfl.experimental.workflow.transport import AggregatorGRPCServer
@@ -142,14 +142,15 @@ class Experiment:
 
         return self.status == Status.FINISHED, self.updated_flow
 
-    async def review_experiment(self, review_plan_callback: Callable[[str, Path], bool]) -> bool:
+    def review_experiment(self, review_plan_callback: Callable[[str, Path], bool]) -> bool:
         """Asynchronously review the experiment plan using the provided callback.
 
         The review runs in a separate thread to avoid blocking the server.
         If rejected, the experiment is marked as REJECTED and its archive is deleted.
 
         Args:
-            review_plan_callback (Callable): A callable that takes (name, plan_path) and returns a bool.
+            review_plan_callback (Callable): A callable that takes (name, plan_path)
+              and returns a bool.
 
         Returns:
             bool: True if approved, False otherwise.
@@ -157,10 +158,7 @@ class Experiment:
         logger.debug("Experiment review started")
         # Extract the workspace for review (without installing requirements)
         with ExperimentWorkspace(
-            self.name,
-            self.archive_path,
-            install_requirements=False,
-            remove_archive=False
+            self.name, self.archive_path, install_requirements=False, remove_archive=False
         ):
             approved = review_plan_callback(self.name, self.plan_path)
 
@@ -170,8 +168,7 @@ class Experiment:
                 return False
 
         return True
-    
-    
+
     def _create_aggregator_grpc_server(
         self,
         *,

--- a/openfl/experimental/workflow/component/director/experiment.py
+++ b/openfl/experimental/workflow/component/director/experiment.py
@@ -142,29 +142,6 @@ class Experiment:
 
         return self.status == Status.FINISHED, self.updated_flow
 
-    async def review_experiment(self, review_plan_callback: Callable) -> bool:
-        """Get plan approve in console."""
-        logger.debug("Experiment Review starts")
-        # Extract the workspace for review (without installing requirements)
-        with ExperimentWorkspace(
-            self.name,
-            self.archive_path,
-            install_requirements=False,
-            remove_archive=False
-        ):
-            loop = asyncio.get_event_loop()
-            # Call for a review in a separate thread (server is not blocked)
-            review_approve = await loop.run_in_executor(
-                None,
-                review_plan_callback,
-                self.name, self.plan_path
-            )
-            if not review_approve:
-                self.status = Status.REJECTED
-                self.archive_path.unlink(missing_ok=True)
-                return False
-        return True
-
     def _create_aggregator_grpc_server(
         self,
         *,

--- a/openfl/experimental/workflow/component/director/experiment.py
+++ b/openfl/experimental/workflow/component/director/experiment.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from contextlib import asynccontextmanager
 from enum import Enum, auto
 from pathlib import Path
+from datetime import datetime,timezone
 from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
 
 from openfl.experimental.workflow.federated import Plan
@@ -151,6 +152,27 @@ class Experiment:
             raise
 
         return self.status == Status.FINISHED, self.updated_flow
+    
+    def record_review(self, reviewer: str, approved: bool) -> None:
+        """
+         Record a review decision for a given reviewer.
+
+         This method appends a structured review entry to the `review_details`
+         dictionary for the specified reviewer, including the reviewer's name,
+         decision status ("APPROVED" or "REJECTED"), and a UTC timestamp.
+
+         Args:
+           reviewer (str): The name or identifier of the reviewer (e.g., 'Director', envoy name).
+           approved (bool): The decision of the reviewer.
+                            Pass True for approval and False for rejection.
+
+        """
+        self.review_details[reviewer].append({
+            'reviewer_name': reviewer,
+            'decision': "APPROVED" if approved else "REJECTED",
+            'timestamp': datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+        })
+
     def signal_review_completion(self) -> None:
         """Signal that the review process is complete.
         

--- a/openfl/experimental/workflow/component/director/experiment.py
+++ b/openfl/experimental/workflow/component/director/experiment.py
@@ -142,6 +142,43 @@ class Experiment:
 
         return self.status == Status.FINISHED, self.updated_flow
 
+    async def review_experiment(self, review_plan_callback: Callable[[str, Path], bool]) -> bool:
+        """Asynchronously review the experiment plan using the provided callback.
+
+        The review runs in a separate thread to avoid blocking the server.
+        If rejected, the experiment is marked as REJECTED and its archive is deleted.
+
+        Args:
+            review_plan_callback (Callable): A callable that takes (name, plan_path) and returns a bool.
+
+        Returns:
+            bool: True if approved, False otherwise.
+        """
+        logger.debug("Experiment review started")
+        # Extract the workspace for review (without installing requirements)
+        with ExperimentWorkspace(
+            self.name,
+            self.archive_path,
+            install_requirements=False,
+            remove_archive=False
+        ):
+            loop = asyncio.get_event_loop()
+            # Call for a review in a separate thread (server is not blocked)
+            approved = await loop.run_in_executor(
+                None,
+                review_plan_callback,
+                self.name,
+                self.plan_path
+            )
+
+            if not approved:
+                self.status = Status.REJECTED
+                self.archive_path.unlink(missing_ok=True)
+                return False
+
+        return True
+    
+    
     def _create_aggregator_grpc_server(
         self,
         *,

--- a/openfl/experimental/workflow/component/director/experiment.py
+++ b/openfl/experimental/workflow/component/director/experiment.py
@@ -85,7 +85,7 @@ class Experiment:
         self.status = Status.PENDING
         self.aggregator = None
         self.updated_flow = None
-        self.review_responses = defaultdict(dict)
+        self.review_responses = {} #{envoy_name: response}
         self.review_decision_event = asyncio.Event()
         self.review_consensus = None
 
@@ -138,7 +138,7 @@ class Experiment:
                 self.aggregator = aggregator_grpc_server.aggregator
                 _, self.updated_flow = await asyncio.gather(
                     self._run_aggregator_grpc_server(
-                        aggregator_grpc_server,
+                        aggregator_grpc_server,self 
                     ),
                     self.aggregator.run_flow(),
                 )
@@ -150,6 +150,14 @@ class Experiment:
             raise
 
         return self.status == Status.FINISHED, self.updated_flow
+    def signal_review_completion(self) -> None:
+        """Signal that the review process is complete.
+        
+        This method sets the review decision event notify waiting processes that the review phase 
+        has been finalized. It is typically called after all review responses have been collected.
+        """
+        self.review_decision_event.set()
+
 
     def review_experiment(self, review_plan_callback: Callable[[str, Path], bool]) -> bool:
         """Review the experiment plan.
@@ -219,7 +227,7 @@ class Experiment:
 
     @staticmethod
     async def _run_aggregator_grpc_server(
-        aggregator_grpc_server: AggregatorGRPCServer,
+        aggregator_grpc_server: AggregatorGRPCServer, experiment
     ) -> None:
         """Run aggregator.
 
@@ -231,7 +239,7 @@ class Experiment:
         grpc_server = aggregator_grpc_server.get_server()
         grpc_server.start()
         logger.info("Starting Aggregator gRPC Server")
-
+        experiment.signal_review_completion()
         try:
             while not aggregator_grpc_server.aggregator.all_quit_jobs_sent():
                 # Awaiting quit job sent to collaborators

--- a/openfl/experimental/workflow/component/director/experiment.py
+++ b/openfl/experimental/workflow/component/director/experiment.py
@@ -6,6 +6,7 @@
 
 import asyncio
 import logging
+from collections import defaultdict
 from contextlib import asynccontextmanager
 from enum import Enum, auto
 from pathlib import Path
@@ -43,6 +44,11 @@ class Experiment:
             status (str): The status of the experiment.
             aggregator (Aggregator): The aggregator instance.
             updated_flow (FLSpec): Updated flow instance.
+            review_responses (defaultdict): A dictionary to store review responses
+            from envoys.
+            _review_decision_event (asyncio.Event): An event to signal the review decision.
+            review_consensus (Optional[bool]): A flag indicating if the review consensus
+                is reached.
     """
 
     def __init__(
@@ -79,6 +85,9 @@ class Experiment:
         self.status = Status.PENDING
         self.aggregator = None
         self.updated_flow = None
+        self.review_responses = defaultdict(dict)
+        self.review_decision_event = asyncio.Event()
+        self.review_consensus = None
 
     async def start(
         self,

--- a/openfl/experimental/workflow/component/director/experiment.py
+++ b/openfl/experimental/workflow/component/director/experiment.py
@@ -86,6 +86,7 @@ class Experiment:
         self.aggregator = None
         self.updated_flow = None
         self.review_responses = {} #{envoy_name: response}
+        self.review_details = defaultdict(list)  # reviewer_name → list of {decision, timestamp}
         self.review_decision_event = asyncio.Event()
         self.review_consensus = None
 

--- a/openfl/experimental/workflow/component/director/experiment.py
+++ b/openfl/experimental/workflow/component/director/experiment.py
@@ -162,14 +162,7 @@ class Experiment:
             install_requirements=False,
             remove_archive=False
         ):
-            loop = asyncio.get_event_loop()
-            # Call for a review in a separate thread (server is not blocked)
-            approved = await loop.run_in_executor(
-                None,
-                review_plan_callback,
-                self.name,
-                self.plan_path
-            )
+            approved = review_plan_callback(self.name, self.plan_path)
 
             if not approved:
                 self.status = Status.REJECTED

--- a/openfl/experimental/workflow/component/director/experiment.py
+++ b/openfl/experimental/workflow/component/director/experiment.py
@@ -143,14 +143,14 @@ class Experiment:
         return self.status == Status.FINISHED, self.updated_flow
 
     def review_experiment(self, review_plan_callback: Callable[[str, Path], bool]) -> bool:
-        """Asynchronously review the experiment plan using the provided callback.
+        """Review the experiment plan.
 
-        The review runs in a separate thread to avoid blocking the server.
-        If rejected, the experiment is marked as REJECTED and its archive is deleted.
+        This method allows for reviewing the experiment plan before it is
+        executed.
 
         Args:
-            review_plan_callback (Callable): A callable that takes (name, plan_path)
-              and returns a bool.
+            review_plan_callback (Callable): A callable that takes
+                (experiment_name, plan_path)
 
         Returns:
             bool: True if approved, False otherwise.
@@ -161,12 +161,13 @@ class Experiment:
             self.name, self.archive_path, install_requirements=False, remove_archive=False
         ):
             approved = review_plan_callback(self.name, self.plan_path)
-
             if not approved:
                 self.status = Status.REJECTED
                 self.archive_path.unlink(missing_ok=True)
+                logger.info(f"Experiment {self.name} rejected")
                 return False
 
+        logger.info(f"Experiment {self.name} approved")
         return True
 
     def _create_aggregator_grpc_server(

--- a/openfl/experimental/workflow/component/director/experiment.py
+++ b/openfl/experimental/workflow/component/director/experiment.py
@@ -9,7 +9,7 @@ import logging
 from contextlib import asynccontextmanager
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Iterable, List, Optional, Tuple, Union
+from typing import Any, Iterable, List, Optional, Tuple, Union, Callable
 
 from openfl.experimental.workflow.federated import Plan
 from openfl.experimental.workflow.transport import AggregatorGRPCServer
@@ -141,6 +141,29 @@ class Experiment:
             raise
 
         return self.status == Status.FINISHED, self.updated_flow
+
+    async def review_experiment(self, review_plan_callback: Callable) -> bool:
+        """Get plan approve in console."""
+        logger.debug("Experiment Review starts")
+        # Extract the workspace for review (without installing requirements)
+        with ExperimentWorkspace(
+            self.name,
+            self.archive_path,
+            install_requirements=False,
+            remove_archive=False
+        ):
+            loop = asyncio.get_event_loop()
+            # Call for a review in a separate thread (server is not blocked)
+            review_approve = await loop.run_in_executor(
+                None,
+                review_plan_callback,
+                self.name, self.plan_path
+            )
+            if not review_approve:
+                self.status = Status.REJECTED
+                self.archive_path.unlink(missing_ok=True)
+                return False
+        return True
 
     def _create_aggregator_grpc_server(
         self,

--- a/openfl/experimental/workflow/component/director/experiment.py
+++ b/openfl/experimental/workflow/component/director/experiment.py
@@ -31,7 +31,9 @@ class Status(Enum):
 
 
 class Experiment:
-    """Experiment class.
+    """ Manages metadata, review, and execution of a federated experiment.
+
+    Tracks status, collaborators, review decisions, and handles aggregator setup
 
     Attributes:
             name (str): The name of the experiment.
@@ -47,6 +49,9 @@ class Experiment:
             updated_flow (FLSpec): Updated flow instance.
             review_responses (defaultdict): A dictionary to store review responses
             from envoys.
+            review_details (defaultdict): A dictionary to store review details
+            for each reviewer, mapping reviewer names to lists of review
+            decisions and timestamps.
             _review_decision_event (asyncio.Event): An event to signal the review decision.
             review_consensus (Optional[bool]): A flag indicating if the review consensus
                 is reached.
@@ -154,12 +159,7 @@ class Experiment:
         return self.status == Status.FINISHED, self.updated_flow
     
     def record_review(self, reviewer: str, approved: bool) -> None:
-        """
-         Record a review decision for a given reviewer.
-
-         This method appends a structured review entry to the `review_details`
-         dictionary for the specified reviewer, including the reviewer's name,
-         decision status ("APPROVED" or "REJECTED"), and a UTC timestamp.
+        """Record a review decision with status and timestamp for the given reviewer.
 
          Args:
            reviewer (str): The name or identifier of the reviewer (e.g., 'Director', envoy name).

--- a/openfl/experimental/workflow/component/envoy/envoy.py
+++ b/openfl/experimental/workflow/component/envoy/envoy.py
@@ -147,42 +147,45 @@ class Envoy:
             data_file_path = self._save_data_stream_to_file(data_stream)
 
             try:
+                # Review phase start
                 with ExperimentWorkspace(
                     experiment_name=f"{self.name}_{experiment_name}",
                     data_file_path=data_file_path,
                     install_requirements=False,
                 ):
                     if self.review_callback:
-                        # envoy to review the experiment before running
-                        logger.info("🧿 Reviewing the experiment plan before running...")
+                        logger.info("🧿 Reviewing the experiment plan before execution...")
                         # If review_plan_callback is provided, call it with the plan config path and the data file path
-                        review_approved = self.review_callback('plan', 'plan/plan.yaml')
+                        is_review_approved = self.review_callback('plan', 'plan/plan.yaml')
+                        review_status = "APPROVE" if is_review_approved else "REJECT"
+                    else:
+                        # Auto-approve if no review callback is provided
+                        review_status = "APPROVE"    
 
-                        review_status = "APPROVE" if review_approved else "REJECT"
-                        # Send the review result to the director
-                        logger.info(f"🧿 Sending review result to the director: {review_status}")
-                         # Send review and wait for Director's approval in the same call
-                        consensus_reached = self._envoy_dir_client.send_experiment_review(
-                            envoy_name=self.name,
-                            experiment_name=experiment_name,
-                            review_status=review_status,
+                    # Send review decision to Director and receive consensus result
+                    logger.info(f"🧿 Sending review result to the director: {review_status}")
+                    consensus_reached = self._envoy_dir_client.send_experiment_review(
+                        envoy_name=self.name,
+                        experiment_name=experiment_name,
+                        review_status=review_status,
                         )
-                        
-                        if not consensus_reached:
-                            # Director says consensus not reached or rejected 
-                            logger.info(f"⚠️ Experiment \"{experiment_name}\" was rejected by Envoy \"{self.name}\".")
-                            continue
-                        logger.debug(f'Experiment "{experiment_name}" is accepted by Envoy "{self.name}".')
-                        time.sleep(self.DEFAULT_RETRY_TIMEOUT_IN_SECONDS) # wait for some time to let aggregator start
-
+                    
+                # Execution phase
+                    if not consensus_reached:
+                        # Director says consensus not reached or rejected 
+                        logger.info(f"⚠️ Experiment \"{experiment_name}\" was rejected by Envoy \"{self.name}\".")
+                        continue
+                    logger.debug(f'Experiment "{experiment_name}" is accepted by Envoy "{self.name}".')
                     # Run the experiment
-                    logger.info("🚀 Starting the experiment...")
-                    # Set the experiment running flag to True to indicate that experiment is running
+                    logger.info("🚀 Starting experiment execution...")
+                    # Set the experiment running flag
                     self.is_experiment_running = True
                     self._run_collaborator()
+ 
             except Exception as exc:
                 logger.exception("Collaborator failed with error: %s:", exc)
             finally:
+                # Reset running flag after execution or failure
                 self.is_experiment_running = False
 
     @staticmethod

--- a/openfl/experimental/workflow/component/envoy/envoy.py
+++ b/openfl/experimental/workflow/component/envoy/envoy.py
@@ -9,7 +9,7 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Optional, Union, Callable
+from typing import Callable, Optional, Union
 
 from openfl.experimental.workflow.federated import Plan
 from openfl.experimental.workflow.transport.grpc.director_client import EnvoyDirectorClient
@@ -56,7 +56,7 @@ class Envoy:
         certificate: Optional[Union[Path, str]] = None,
         tls: bool = True,
         install_requirements: bool = True,
-        review_callback: Union[None,Callable] = None,
+        review_callback: Union[None, Callable] = None,
     ) -> None:
         """Initialize a envoy object.
 
@@ -140,52 +140,31 @@ class Envoy:
                 # Wait for experiment from Director server
                 experiment_name = self._envoy_dir_client.wait_experiment()
                 data_stream = self._envoy_dir_client.get_experiment_data(experiment_name)
+                data_file_path = self._save_data_stream_to_file(data_stream)
             except Exception as exc:
                 logger.exception("Failed to get experiment: %s", exc)
                 time.sleep(self.DEFAULT_RETRY_TIMEOUT_IN_SECONDS)
                 continue
-            data_file_path = self._save_data_stream_to_file(data_stream)
-
             try:
-                # Review phase start
                 with ExperimentWorkspace(
                     experiment_name=f"{self.name}_{experiment_name}",
                     data_file_path=data_file_path,
                     install_requirements=False,
                 ):
-                    if self.review_callback:
-                        logger.info("🧿 Reviewing the experiment plan before execution...")
-                        # If review_plan_callback is provided, call it with the plan config path and the data file path
-                        is_review_approved = self.review_callback('plan', 'plan/plan.yaml')
-                        review_status = "APPROVE" if is_review_approved else "REJECT"
-                    else:
-                        # Auto-approve if no review callback is provided
-                        review_status = "APPROVE"    
-
-                    # Send review decision to Director and receive consensus result
-                    logger.info(f"🧿 Sending review result to the director: {review_status}")
-                    consensus_reached = self._envoy_dir_client.send_experiment_review(
-                        envoy_name=self.name,
-                        experiment_name=experiment_name,
-                        review_status=review_status,
+                    if not self._review_phase(experiment_name):
+                        logger.info(
+                            f'⚠️ Experiment "{experiment_name}" was rejected by Envoy "{self.name}".'
                         )
-                    
-                # Execution phase
-                    if not consensus_reached:
-                        # Director says consensus not reached or rejected 
-                        logger.info(f"⚠️ Experiment \"{experiment_name}\" was rejected by Envoy \"{self.name}\".")
                         continue
-                    logger.debug(f'Experiment "{experiment_name}" is accepted by Envoy "{self.name}".')
-                    # Run the experiment
+                    logger.info(
+                        f'Experiment "{experiment_name}" is accepted by Envoy "{self.name}".'
+                    )
                     logger.info("🚀 Starting experiment execution...")
-                    # Set the experiment running flag
                     self.is_experiment_running = True
                     self._run_collaborator()
- 
             except Exception as exc:
                 logger.exception("Collaborator failed with error: %s:", exc)
             finally:
-                # Reset running flag after execution or failure
                 self.is_experiment_running = False
 
     @staticmethod
@@ -206,6 +185,29 @@ class Envoy:
                 else:
                     raise Exception("Broken archive")
         return data_file_path
+
+    def _review_phase(self, experiment_name: str) -> bool:
+        """Review phase for the experiment.
+
+        Args:
+            experiment_name (str): The name of the experiment.
+
+        Returns:
+            bool: True if the review is approved, False otherwise.
+        """
+        review_status = "APPROVE"
+        if self.review_callback:
+            logger.info("🧿 Reviewing the experiment plan before execution...")
+            is_review_approved = self.review_callback("plan", "plan/plan.yaml")
+            review_status = "APPROVE" if is_review_approved else "REJECT"
+
+        logger.info(f"🧿 Sending review result to the director: {review_status}")
+        consensus_reached = self._envoy_dir_client.send_experiment_review(
+            envoy_name=self.name,
+            experiment_name=experiment_name,
+            review_status=review_status,
+        )
+        return consensus_reached
 
     def _send_health_check(self) -> None:
         """Send health check to the director."""

--- a/openfl/experimental/workflow/component/envoy/envoy.py
+++ b/openfl/experimental/workflow/component/envoy/envoy.py
@@ -150,7 +150,7 @@ class Envoy:
                 with ExperimentWorkspace(
                     experiment_name=f"{self.name}_{experiment_name}",
                     data_file_path=data_file_path,
-                    install_requirements=self.install_requirements,
+                    install_requirements=False,
                 ):
                     if self.review_callback:
                         # envoy to review the experiment before running
@@ -173,6 +173,7 @@ class Envoy:
                             logger.info(f"⚠️ Experiment \"{experiment_name}\" was rejected by Envoy \"{self.name}\".")
                             continue
                         logger.debug(f'Experiment "{experiment_name}" is accepted by Envoy "{self.name}".')
+                        time.sleep(self.DEFAULT_RETRY_TIMEOUT_IN_SECONDS) # wait for some time to let aggregator start
 
                     # Run the experiment
                     logger.info("🚀 Starting the experiment...")

--- a/openfl/experimental/workflow/component/envoy/envoy.py
+++ b/openfl/experimental/workflow/component/envoy/envoy.py
@@ -40,6 +40,8 @@ class Envoy:
         executor (ThreadPoolExecutor): The executor for running tasks.
         plan(str): Path to plan.yaml
         _health_check_future (object): The future object for the health check.
+        review_callback (Optional[Callable]): A callback function for reviewing
+            the experiment plan before execution.
     """
 
     DEFAULT_RETRY_TIMEOUT_IN_SECONDS = 5
@@ -198,7 +200,7 @@ class Envoy:
         review_status = "APPROVE"
         if self.review_callback:
             logger.info("🧿 Reviewing the experiment plan before execution...")
-            is_review_approved = self.review_callback("plan", "plan/plan.yaml")
+            is_review_approved = self.review_callback(self.name, self.plan )
             review_status = "APPROVE" if is_review_approved else "REJECT"
 
         logger.info(f"🧿 Sending review result to the director: {review_status}")

--- a/openfl/experimental/workflow/component/envoy/envoy.py
+++ b/openfl/experimental/workflow/component/envoy/envoy.py
@@ -9,7 +9,7 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, Callable
 
 from openfl.experimental.workflow.federated import Plan
 from openfl.experimental.workflow.transport.grpc.director_client import EnvoyDirectorClient
@@ -56,6 +56,7 @@ class Envoy:
         certificate: Optional[Union[Path, str]] = None,
         tls: bool = True,
         install_requirements: bool = True,
+        review_callback: Union[None,Callable] = None,
     ) -> None:
         """Initialize a envoy object.
 
@@ -87,6 +88,7 @@ class Envoy:
         # experiment workspace provided by the director
         self.plan = "plan/plan.yaml"
         self._health_check_future = None
+        self.review_callback = review_callback
 
     def _create_envoy_dir_client(
         self, director_host: str, director_port: int
@@ -150,6 +152,31 @@ class Envoy:
                     data_file_path=data_file_path,
                     install_requirements=self.install_requirements,
                 ):
+                    if self.review_callback:
+                        # envoy to review the experiment before running
+                        logger.info("🧿 Reviewing the experiment plan before running...")
+                        # If review_plan_callback is provided, call it with the plan config path and the data file path
+                        review_approved = self.review_callback('plan', 'plan/plan.yaml')
+
+                        review_status = "APPROVE" if review_approved else "REJECT"
+                        # Send the review result to the director
+                        logger.info(f"🧿 Sending review result to the director: {review_status}")
+                         # Send review and wait for Director's approval in the same call
+                        consensus_reached = self._envoy_dir_client.send_experiment_review(
+                            envoy_name=self.name,
+                            experiment_name=experiment_name,
+                            review_status=review_status,
+                        )
+                        
+                        if not consensus_reached:
+                            # Director says consensus not reached or rejected 
+                            logger.info(f"⚠️ Experiment \"{experiment_name}\" was rejected by Envoy \"{self.name}\".")
+                            continue
+                        logger.debug(f'Experiment "{experiment_name}" is accepted by Envoy "{self.name}".')
+
+                    # Run the experiment
+                    logger.info("🚀 Starting the experiment...")
+                    # Set the experiment running flag to True to indicate that experiment is running
                     self.is_experiment_running = True
                     self._run_collaborator()
             except Exception as exc:

--- a/openfl/experimental/workflow/interface/cli/cli_helper.py
+++ b/openfl/experimental/workflow/interface/cli/cli_helper.py
@@ -143,7 +143,7 @@ def replace_line_in_file(line, line_num_to_replace, filename):
 
 
 
-def custom_confirm(prompt_message: str) -> bool:
+def prompt_confirmation(prompt_message: str) -> bool:
     """
     Custom function to prompt for user confirmation, handling Ctrl+C explicitly.
 
@@ -200,7 +200,7 @@ def review_plan_callback(file_name: str, file_path) -> bool:
 
     try:
         # Ask for user confirmation to accept the file
-        if custom_confirm("Do you want to accept the 📂 {file_name}❔"):
+        if prompt_confirmation("Do you want to accept the 📂 {file_name}❔"):
             echo(style(f"{file_name} accepted!", fg="green", bold=True))
             return True
         else:

--- a/openfl/experimental/workflow/interface/cli/cli_helper.py
+++ b/openfl/experimental/workflow/interface/cli/cli_helper.py
@@ -142,6 +142,33 @@ def replace_line_in_file(line, line_num_to_replace, filename):
         f.truncate()
 
 
+
+def custom_confirm(prompt_message: str) -> bool:
+    """
+    Custom function to prompt for user confirmation, handling Ctrl+C explicitly.
+
+    Args:
+        prompt_message (str): The question to ask the user.
+
+    Returns:
+        bool: True if the user enters 'Y' or 'y'; False otherwise.
+    """
+    while True:
+        try:
+            echo(style(prompt_message + " [Y/N]: ", fg="green", bold=True), nl=False)
+            response = input().strip().lower()
+
+            if response in ["y", "yes"]:
+                return True
+            elif response in ["n", "no"]:
+                return False
+            else:
+                echo(style("Error: invalid input. Please enter 'Y' or 'N'.", fg="red", bold=True))
+        except KeyboardInterrupt:
+            echo(style("\nUser interrupted (Ctrl+C). Treating as rejection.", fg="red", bold=True))
+            return False  # Explicitly treat Ctrl+C as rejection
+
+
 def review_plan_callback(file_name: str, file_path) -> bool:
     """
     Review plan callback for Director and Envoy.
@@ -171,10 +198,14 @@ def review_plan_callback(file_name: str, file_path) -> bool:
         echo(style(f"⚠️ Failed to read file: {e}", fg="red", bold=True))
         return False
 
-    # Ask for user confirmation to accept the file
-    if confirm(style(f"Do you want to accept the 📂 {file_name}❔", fg="green", bold=True)):
-        echo(style(f"{file_name} accepted!", fg="green", bold=True))
-        return True
-    else:
-        echo(style(f"{file_name} rejected!", fg="red", bold=True))
-        return False  # Return False on rejection
+    try:
+        # Ask for user confirmation to accept the file
+        if custom_confirm("Do you want to accept the 📂 {file_name}❔"):
+            echo(style(f"{file_name} accepted!", fg="green", bold=True))
+            return True
+        else:
+            echo(style(f"{file_name} rejected!", fg="red", bold=True))
+            return False  # Return False on rejection
+    except KeyboardInterrupt:
+        echo(style(f"\n{file_name} rejected by user.", fg="red", bold=True))
+        return False   

--- a/openfl/experimental/workflow/interface/cli/cli_helper.py
+++ b/openfl/experimental/workflow/interface/cli/cli_helper.py
@@ -12,7 +12,7 @@ from os import environ
 from pathlib import Path
 from sys import argv
 
-from click import echo, style, confirm, open_file
+from click import confirm, echo, open_file, style
 from yaml import FullLoader, load
 
 FX = argv[0]
@@ -141,6 +141,7 @@ def replace_line_in_file(line, line_num_to_replace, filename):
                 f.write(i)
         f.truncate()
 
+
 def review_plan_callback(file_name: str, file_path) -> bool:
     """
     Review plan callback for Director and Envoy.
@@ -154,7 +155,13 @@ def review_plan_callback(file_name: str, file_path) -> bool:
     """
     DISPLAY_DELAY_SECONDS = 3
 
-    echo(style(f"🧿 Please review the contents of 📂 {file_name} before proceeding...", fg="green", bold=True))
+    echo(
+        style(
+            f"🧿 Please review the contents of 📂 {file_name} before proceeding...",
+            fg="green",
+            bold=True,
+        )
+    )
     time.sleep(DISPLAY_DELAY_SECONDS)
 
     try:

--- a/openfl/experimental/workflow/interface/cli/cli_helper.py
+++ b/openfl/experimental/workflow/interface/cli/cli_helper.py
@@ -12,7 +12,7 @@ from os import environ
 from pathlib import Path
 from sys import argv
 
-from click import confirm, echo, open_file, style
+from click import echo, open_file, style
 from yaml import FullLoader, load
 
 FX = argv[0]

--- a/openfl/experimental/workflow/interface/cli/cli_helper.py
+++ b/openfl/experimental/workflow/interface/cli/cli_helper.py
@@ -6,12 +6,13 @@
 
 import os
 import re
+import time
 from itertools import islice
 from os import environ
 from pathlib import Path
 from sys import argv
 
-from click import echo, style
+from click import echo, style, confirm, open_file
 from yaml import FullLoader, load
 
 FX = argv[0]
@@ -139,3 +140,34 @@ def replace_line_in_file(line, line_num_to_replace, filename):
             else:
                 f.write(i)
         f.truncate()
+
+def review_plan_callback(file_name: str, file_path) -> bool:
+    """
+    Review plan callback for Director and Envoy.
+
+    Args:
+        file_name (str): Display name of the file to be reviewed.
+        file_path (Union[str, Path]): Path to the file containing the plan.
+
+    Returns:
+        bool: True if the user approves the file; False otherwise.
+    """
+    DISPLAY_DELAY_SECONDS = 3
+
+    echo(style(f"🧿 Please review the contents of 📂 {file_name} before proceeding...", fg="green", bold=True))
+    time.sleep(DISPLAY_DELAY_SECONDS)
+
+    try:
+        with open_file(file_path, "r") as f:
+            echo(f.read())
+    except Exception as e:
+        echo(style(f"⚠️ Failed to read file: {e}", fg="red", bold=True))
+        return False
+
+    # Ask for user confirmation to accept the file
+    if confirm(style(f"Do you want to accept the 📂 {file_name}❔", fg="green", bold=True)):
+        echo(style(f"{file_name} accepted!", fg="green", bold=True))
+        return True
+    else:
+        echo(style(f"{file_name} rejected!", fg="red", bold=True))
+        return False  # Return False on rejection

--- a/openfl/experimental/workflow/interface/cli/director.py
+++ b/openfl/experimental/workflow/interface/cli/director.py
@@ -15,6 +15,7 @@ from openfl.experimental.workflow.component.director import Director
 from openfl.experimental.workflow.transport import DirectorGRPCServer
 from openfl.utilities import merge_configs
 from openfl.utilities.path_check import is_directory_traversal
+from openfl.experimental.workflow.interface.cli.cli_helper import review_plan_callback
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +105,7 @@ def start(director_config_path, tls, root_certificate, private_key, certificate)
                 gte=1,
                 lte=24 * 60 * 60,
             ),
+            Validator("settings.review_experiment", default=False),
         ],
     )
 
@@ -116,6 +118,11 @@ def start(director_config_path, tls, root_certificate, private_key, certificate)
     if config.certificate:
         config.certificate = Path(config.certificate).absolute()
 
+    # Check if review_experiment is enabled in the configuration
+    review_experiment = config.settings.review_experiment
+    # Set the review callback if review_experiment is True
+    review_callback = review_plan_callback if review_experiment else None
+
     director_server = DirectorGRPCServer(
         director_cls=Director,
         tls=tls,
@@ -127,5 +134,6 @@ def start(director_config_path, tls, root_certificate, private_key, certificate)
         envoy_health_check_period=config.settings.envoy_health_check_period,
         install_requirements=config.settings.install_requirements,
         director_config=director_config_path,
+        review_callback=review_callback,
     )
     director_server.start()

--- a/openfl/experimental/workflow/interface/cli/director.py
+++ b/openfl/experimental/workflow/interface/cli/director.py
@@ -12,10 +12,10 @@ from click import group, option, pass_context
 from dynaconf import Validator
 
 from openfl.experimental.workflow.component.director import Director
+from openfl.experimental.workflow.interface.cli.cli_helper import review_plan_callback
 from openfl.experimental.workflow.transport import DirectorGRPCServer
 from openfl.utilities import merge_configs
 from openfl.utilities.path_check import is_directory_traversal
-from openfl.experimental.workflow.interface.cli.cli_helper import review_plan_callback
 
 logger = logging.getLogger(__name__)
 

--- a/openfl/experimental/workflow/interface/cli/envoy.py
+++ b/openfl/experimental/workflow/interface/cli/envoy.py
@@ -14,6 +14,7 @@ from dynaconf import Validator
 from openfl.experimental.workflow.component.envoy import Envoy
 from openfl.utilities import is_fqdn, merge_configs
 from openfl.utilities.path_check import is_directory_traversal
+from openfl.experimental.workflow.interface.cli.cli_helper import review_plan_callback
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +127,7 @@ def start_(
                 },
             ),
             Validator("params.install_requirements", default=True),
+            Validator("settings.review_experiment", default=False),
         ],
     )
 
@@ -143,6 +145,12 @@ def start_(
     if config.certificate:
         config.certificate = Path(config.certificate).absolute()
 
+    # Check if review_experiment is enabled in the settings
+    review_experiment = config.settings.review_experiment
+
+    # Set the review callback if review_experiment is True
+    review_callback = review_plan_callback if review_experiment else None
+
     envoy = Envoy(
         envoy_name=envoy_name,
         director_host=config.settings.director_host,
@@ -153,6 +161,7 @@ def start_(
         certificate=config.certificate,
         tls=tls,
         install_requirements=install_requirements,
+        review_callback=review_callback,
     )
 
     envoy.start()

--- a/openfl/experimental/workflow/interface/cli/envoy.py
+++ b/openfl/experimental/workflow/interface/cli/envoy.py
@@ -12,9 +12,9 @@ from click import group, option, pass_context
 from dynaconf import Validator
 
 from openfl.experimental.workflow.component.envoy import Envoy
+from openfl.experimental.workflow.interface.cli.cli_helper import review_plan_callback
 from openfl.utilities import is_fqdn, merge_configs
 from openfl.utilities.path_check import is_directory_traversal
-from openfl.experimental.workflow.interface.cli.cli_helper import review_plan_callback
 
 logger = logging.getLogger(__name__)
 

--- a/openfl/experimental/workflow/interface/fl_spec.py
+++ b/openfl/experimental/workflow/interface/fl_spec.py
@@ -194,11 +194,10 @@ class FLSpec:
             archive_path, exp_name = self.runtime.prepare_workspace_archive()
             submission_result = self.runtime.submit_experiment(archive_path, exp_name)
             if not submission_result:
-              print(f"\033[91m? Experiment '{exp_name}' was rejected by the Director.\033[0m")
+              print(f"\033[91m ❌Experiment '{exp_name}' was rejected.\033[0m")
               return 
-              #raise Exception(f"Experiment '{exp_name}' submission was rejected. Stopping execution.")
             #  Experiment was submitted successfully
-            print(f"\033[92m? Experiment '{exp_name}' approved and running.\033[0m")
+            print(f"\033[92m✅Experiment '{exp_name}' approved and running.\033[0m")
             # Stream the experiment's stdout if the checkpoint is enabled
             if self._checkpoint:
                 self.runtime.stream_experiment_stdout(exp_name)

--- a/openfl/experimental/workflow/interface/fl_spec.py
+++ b/openfl/experimental/workflow/interface/fl_spec.py
@@ -189,7 +189,7 @@ class FLSpec:
             submission_result = self.runtime.submit_experiment(archive_path, exp_name)
             #print("submission_result.review_statuses:",submission_result.review_statuses)
             for review in submission_result.review_statuses:
-                print(f"{review.reviewer}: {review.decision} , {review.timestamp}")
+                print(f"\033[92m{review.reviewer}: {review.decision} , {review.timestamp}\033[0m")
             if not submission_result.status:
                 print(f"\033[91m ❌Experiment '{exp_name}' was rejected.\033[0m")
                 return

--- a/openfl/experimental/workflow/interface/fl_spec.py
+++ b/openfl/experimental/workflow/interface/fl_spec.py
@@ -187,7 +187,10 @@ class FLSpec:
             # Prepare workspace and submit it for the FederatedRuntime
             archive_path, exp_name = self.runtime.prepare_workspace_archive()
             submission_result = self.runtime.submit_experiment(archive_path, exp_name)
-            if not submission_result:
+            #print("submission_result.review_statuses:",submission_result.review_statuses)
+            for review in submission_result.review_statuses:
+                print(f"{review.reviewer}: {review.decision} , {review.timestamp}")
+            if not submission_result.status:
                 print(f"\033[91m ❌Experiment '{exp_name}' was rejected.\033[0m")
                 return
             #  Experiment was submitted successfully

--- a/openfl/experimental/workflow/interface/fl_spec.py
+++ b/openfl/experimental/workflow/interface/fl_spec.py
@@ -195,7 +195,8 @@ class FLSpec:
             submission_result = self.runtime.submit_experiment(archive_path, exp_name)
             if not submission_result:
               print(f"\033[91m? Experiment '{exp_name}' was rejected by the Director.\033[0m")
-              raise Exception(f"Experiment '{exp_name}' submission was rejected. Stopping execution.")
+              return 
+              #raise Exception(f"Experiment '{exp_name}' submission was rejected. Stopping execution.")
             #  Experiment was submitted successfully
             print(f"\033[92m? Experiment '{exp_name}' approved and running.\033[0m")
             # Stream the experiment's stdout if the checkpoint is enabled
@@ -204,7 +205,8 @@ class FLSpec:
             # Retrieve the flspec object to update the experiment state
             flspec_obj = self._get_flow_state()
             # Update state of self
-            self._update_from_flspec_obj(flspec_obj)
+            if flspec_obj:
+                self._update_from_flspec_obj(flspec_obj)
         except Exception as e:
             raise Exception(
                 f"FederatedRuntime: Experiment {exp_name} failed to run due to error: {e}"

--- a/openfl/experimental/workflow/interface/fl_spec.py
+++ b/openfl/experimental/workflow/interface/fl_spec.py
@@ -125,18 +125,13 @@ class FLSpec:
 
     def run(self) -> None:
         """Starts the execution of the flow."""
-        try:
-            # Submit flow to Runtime
-            if str(self._runtime) == "LocalRuntime":
-                self._run_local()
-            elif str(self._runtime) == "FederatedRuntime":
-                self._run_federated()
-            else:
-                raise Exception("Runtime not implemented")
-        except Exception as e:
-            # Stop execution and print error message
-            print(f"\033[91m? Flow execution stopped: {e}\033[0m")
-            raise
+        # Submit flow to Runtime
+        if str(self._runtime) == "LocalRuntime":
+            self._run_local()
+        elif str(self._runtime) == "FederatedRuntime":
+            self._run_federated()
+        else:
+            raise Exception("Runtime not implemented")
 
     def _run_local(self) -> None:
         """Executes the flow using LocalRuntime."""

--- a/openfl/experimental/workflow/interface/fl_spec.py
+++ b/openfl/experimental/workflow/interface/fl_spec.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import inspect
 from copy import deepcopy
+from click import style
 from typing import TYPE_CHECKING, Callable, List, Type, Union
 
 if TYPE_CHECKING:
@@ -22,6 +23,17 @@ from openfl.experimental.workflow.utilities import (
     generate_artifacts,
     should_transfer,
 )
+
+class Bcolors:
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    HEADER = "\033[95m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+    ENDC = "\033[0m"
 
 
 class FLSpec:
@@ -187,14 +199,13 @@ class FLSpec:
             # Prepare workspace and submit it for the FederatedRuntime
             archive_path, exp_name = self.runtime.prepare_workspace_archive()
             submission_result = self.runtime.submit_experiment(archive_path, exp_name)
-            #print("submission_result.review_statuses:",submission_result.review_statuses)
             for review in submission_result.review_statuses:
-                print(f"\033[92m{review.reviewer}: {review.decision} , {review.timestamp}\033[0m")
+                print(f"{Bcolors.OKGREEN}{review.reviewer}: {review.decision} , {review.timestamp}{Bcolors.ENDC}")
             if not submission_result.status:
-                print(f"\033[91m ❌Experiment '{exp_name}' was rejected.\033[0m")
+                print(f"{Bcolors.FAIL}❌Experiment '{exp_name}' was rejected.{Bcolors.ENDC}")
                 return
             #  Experiment was submitted successfully
-            print(f"\033[92m✅Experiment '{exp_name}' approved and running.\033[0m")
+            print(f"{Bcolors.OKGREEN}✅Experiment '{exp_name}' approved and running.{Bcolors.ENDC}")
             # Stream the experiment's stdout if the checkpoint is enabled
             if self._checkpoint:
                 self.runtime.stream_experiment_stdout(exp_name)

--- a/openfl/experimental/workflow/interface/fl_spec.py
+++ b/openfl/experimental/workflow/interface/fl_spec.py
@@ -125,13 +125,19 @@ class FLSpec:
 
     def run(self) -> None:
         """Starts the execution of the flow."""
-        # Submit flow to Runtime
-        if str(self._runtime) == "LocalRuntime":
-            self._run_local()
-        elif str(self._runtime) == "FederatedRuntime":
-            self._run_federated()
-        else:
-            raise Exception("Runtime not implemented")
+        try:
+            # Submit flow to Runtime
+            if str(self._runtime) == "LocalRuntime":
+                self._run_local()
+            elif str(self._runtime) == "FederatedRuntime":
+                self._run_federated()
+            else:
+                raise Exception("Runtime not implemented")
+        except Exception as e:
+            # Stop execution and print error message
+            print(f"\033[91m? Flow execution stopped: {e}\033[0m")
+            raise
+        
 
     def _run_local(self) -> None:
         """Executes the flow using LocalRuntime."""
@@ -186,7 +192,12 @@ class FLSpec:
         try:
             # Prepare workspace and submit it for the FederatedRuntime
             archive_path, exp_name = self.runtime.prepare_workspace_archive()
-            self.runtime.submit_experiment(archive_path, exp_name)
+            submission_result = self.runtime.submit_experiment(archive_path, exp_name)
+            if not submission_result:
+              print(f"\033[91m? Experiment '{exp_name}' was rejected by the Director.\033[0m")
+              raise Exception(f"Experiment '{exp_name}' submission was rejected. Stopping execution.")
+            #  Experiment was submitted successfully
+            print(f"\033[92m? Experiment '{exp_name}' approved and running.\033[0m")
             # Stream the experiment's stdout if the checkpoint is enabled
             if self._checkpoint:
                 self.runtime.stream_experiment_stdout(exp_name)

--- a/openfl/experimental/workflow/interface/fl_spec.py
+++ b/openfl/experimental/workflow/interface/fl_spec.py
@@ -137,7 +137,6 @@ class FLSpec:
             # Stop execution and print error message
             print(f"\033[91m? Flow execution stopped: {e}\033[0m")
             raise
-        
 
     def _run_local(self) -> None:
         """Executes the flow using LocalRuntime."""
@@ -194,8 +193,8 @@ class FLSpec:
             archive_path, exp_name = self.runtime.prepare_workspace_archive()
             submission_result = self.runtime.submit_experiment(archive_path, exp_name)
             if not submission_result:
-              print(f"\033[91m ❌Experiment '{exp_name}' was rejected.\033[0m")
-              return 
+                print(f"\033[91m ❌Experiment '{exp_name}' was rejected.\033[0m")
+                return
             #  Experiment was submitted successfully
             print(f"\033[92m✅Experiment '{exp_name}' approved and running.\033[0m")
             # Stream the experiment's stdout if the checkpoint is enabled

--- a/openfl/experimental/workflow/protocols/director.proto
+++ b/openfl/experimental/workflow/protocols/director.proto
@@ -15,6 +15,7 @@ service Director {
     rpc WaitExperiment(WaitExperimentRequest) returns (WaitExperimentResponse) {}
     rpc GetExperimentData(GetExperimentDataRequest) returns (stream ExperimentData) {}
     rpc UpdateEnvoyStatus(UpdateEnvoyStatusRequest) returns (UpdateEnvoyStatusResponse) {}
+    rpc SendExperimentReview(SendExperimentReviewRequest) returns (SendExperimentReviewResponse) {}
 
     //Runtime RPCs
     rpc SetNewExperiment(stream ExperimentInfo) returns (SetNewExperimentResponse) {}
@@ -59,6 +60,16 @@ message UpdateEnvoyStatusResponse {
     google.protobuf.Duration health_check_period = 1;
 }
 
+message SendExperimentReviewRequest {
+    string envoy_name = 1;
+    string experiment_name = 2;
+    string review_status = 3;  // "APPROVE" or "REJECT"
+}
+
+message SendExperimentReviewResponse {
+    bool consensus_reached = 1 // True if all participants (Director + Envoys) have approved, False otherwise
+}
+
 message ExperimentInfo {
     string name = 1;
     repeated string collaborator_names = 2;
@@ -66,7 +77,7 @@ message ExperimentInfo {
 }
 
 message SetNewExperimentResponse {
-    bool status = 1;
+    bool status = 1; // True if approved, False if rejected
 }
 
 message EnvoyInfo {

--- a/openfl/experimental/workflow/protocols/director.proto
+++ b/openfl/experimental/workflow/protocols/director.proto
@@ -67,7 +67,7 @@ message SendExperimentReviewRequest {
 }
 
 message SendExperimentReviewResponse {
-    bool consensus_reached = 1 // True if all participants (Director + Envoys) have approved, False otherwise
+    bool consensus_reached = 1; // True if all participants (Director + Envoys) have approved, False otherwise
 }
 
 message ExperimentInfo {

--- a/openfl/experimental/workflow/protocols/director.proto
+++ b/openfl/experimental/workflow/protocols/director.proto
@@ -63,11 +63,11 @@ message UpdateEnvoyStatusResponse {
 message SendExperimentReviewRequest {
     string envoy_name = 1;
     string experiment_name = 2;
-    string review_status = 3;  // "APPROVE" or "REJECT"
+    string review_status = 3;
 }
 
 message SendExperimentReviewResponse {
-    bool consensus_reached = 1; // True if all participants (Director + Envoys) have approved, False otherwise
+    bool consensus_reached = 1; 
 }
 
 message ExperimentInfo {
@@ -77,7 +77,7 @@ message ExperimentInfo {
 }
 
 message SetNewExperimentResponse {
-    bool status = 1; // True if approved, False if rejected
+    bool status = 1;
 }
 
 message EnvoyInfo {

--- a/openfl/experimental/workflow/protocols/director.proto
+++ b/openfl/experimental/workflow/protocols/director.proto
@@ -76,8 +76,15 @@ message ExperimentInfo {
     ExperimentData experiment_data = 3;
 }
 
+message ExperimentReviewStatus {
+    string reviewer = 1;
+    string decision = 2;
+    string timestamp = 3;
+}
+
 message SetNewExperimentResponse {
     bool status = 1;
+    repeated ExperimentReviewStatus review_statuses = 2;
 }
 
 message EnvoyInfo {

--- a/openfl/experimental/workflow/runtime/federated_runtime.py
+++ b/openfl/experimental/workflow/runtime/federated_runtime.py
@@ -155,13 +155,16 @@ class FederatedRuntime(Runtime):
         )
         return archive_path, exp_name
 
-    def submit_experiment(self, archive_path, exp_name) -> None:
+    def submit_experiment(self, archive_path, exp_name) -> bool:
         """
         Submits experiment archive to the director
 
         Args:
             archive_path (str): Archive file path containing the workspace.
             exp_name (str): The name of the experiment to be submitted.
+        
+        Returns:
+            bool: True if experiment was accepted or submitted succesfully , False if rejected or not submitted to director
         """
         try:
             response = self._runtime_dir_client.set_new_experiment(
@@ -170,12 +173,14 @@ class FederatedRuntime(Runtime):
             self.experiment_submitted = response.status
 
             if self.experiment_submitted:
-                print(
-                    f"\033[92mExperiment {exp_name} was successfully "
-                    "submitted to the director!\033[0m"
-                )
+                print(f"\033[92m?Experiment '{exp_name}' was successfully submitted!\033[0m")
+                return True
             else:
-                print(f"\033[91mFailed to submit experiment '{exp_name}' to the director.\033[0m")
+                #print(f"\033[91m ?Experiment '{exp_name}' submission was rejected by the Director\033[0m")
+                return False
+                #raise RuntimeError(
+                    #f"Failed to submit experiment '{exp_name}' to the director. Rejected by director."
+                #)
         finally:
             self.remove_workspace_archive(archive_path)
 

--- a/openfl/experimental/workflow/runtime/federated_runtime.py
+++ b/openfl/experimental/workflow/runtime/federated_runtime.py
@@ -19,8 +19,6 @@ from tabulate import tabulate
 from openfl.experimental.workflow.notebooktools import NotebookTools
 from openfl.experimental.workflow.runtime.runtime import Runtime
 from openfl.experimental.workflow.transport.grpc.director_client import RuntimeDirectorClient
-
-# Import SetNewExperimentResponse from the appropriate module
 from openfl.experimental.workflow.protocols import director_pb2 
 
 logger = logging.getLogger(__name__)

--- a/openfl/experimental/workflow/runtime/federated_runtime.py
+++ b/openfl/experimental/workflow/runtime/federated_runtime.py
@@ -17,9 +17,10 @@ import dill
 from tabulate import tabulate
 
 from openfl.experimental.workflow.notebooktools import NotebookTools
+from openfl.experimental.workflow.protocols import director_pb2
 from openfl.experimental.workflow.runtime.runtime import Runtime
 from openfl.experimental.workflow.transport.grpc.director_client import RuntimeDirectorClient
-from openfl.experimental.workflow.protocols import director_pb2 
+ 
 
 logger = logging.getLogger(__name__)
 

--- a/openfl/experimental/workflow/runtime/federated_runtime.py
+++ b/openfl/experimental/workflow/runtime/federated_runtime.py
@@ -166,21 +166,13 @@ class FederatedRuntime(Runtime):
             exp_name (str): The name of the experiment to be submitted.
 
         Returns:
-            director_pb2.SetNewExperimentResponsee: gRPC response from the director.
+            director_pb2.SetNewExperimentResponse: gRPC response from the director.
         """
         try:
             response = self._runtime_dir_client.set_new_experiment(
                 archive_path=archive_path, experiment_name=exp_name, col_names=self.__collaborators
             )
             return response
-            
-            #self.experiment_submitted = response.status
-
-            #if self.experiment_submitted:
-                #print(f"\033[92m✅Experiment '{exp_name}' was successfully submitted!\033[0m")
-                #return True
-            #else:
-                #return False
         finally:
             self.remove_workspace_archive(archive_path)
 

--- a/openfl/experimental/workflow/runtime/federated_runtime.py
+++ b/openfl/experimental/workflow/runtime/federated_runtime.py
@@ -173,7 +173,7 @@ class FederatedRuntime(Runtime):
             self.experiment_submitted = response.status
 
             if self.experiment_submitted:
-                print(f"\033[92m?Experiment '{exp_name}' was successfully submitted!\033[0m")
+                print(f"\033[92m✅Experiment '{exp_name}' was successfully submitted!\033[0m")
                 return True
             else:
                 #print(f"\033[91m ?Experiment '{exp_name}' submission was rejected by the Director\033[0m")

--- a/openfl/experimental/workflow/runtime/federated_runtime.py
+++ b/openfl/experimental/workflow/runtime/federated_runtime.py
@@ -20,6 +20,9 @@ from openfl.experimental.workflow.notebooktools import NotebookTools
 from openfl.experimental.workflow.runtime.runtime import Runtime
 from openfl.experimental.workflow.transport.grpc.director_client import RuntimeDirectorClient
 
+# Import SetNewExperimentResponse from the appropriate module
+from openfl.experimental.workflow.protocols import director_pb2 
+
 logger = logging.getLogger(__name__)
 
 
@@ -155,7 +158,7 @@ class FederatedRuntime(Runtime):
         )
         return archive_path, exp_name
 
-    def submit_experiment(self, archive_path, exp_name) -> bool:
+    def submit_experiment(self, archive_path, exp_name) -> director_pb2.SetNewExperimentResponse:
         """
         Submits experiment archive to the director
 
@@ -164,20 +167,21 @@ class FederatedRuntime(Runtime):
             exp_name (str): The name of the experiment to be submitted.
 
         Returns:
-            bool: True if experiment was accepted or submitted succesfully
-                , False if rejected or not submitted to director
+            director_pb2.SetNewExperimentResponsee: gRPC response from the director.
         """
         try:
             response = self._runtime_dir_client.set_new_experiment(
                 archive_path=archive_path, experiment_name=exp_name, col_names=self.__collaborators
             )
-            self.experiment_submitted = response.status
+            return response
+            
+            #self.experiment_submitted = response.status
 
-            if self.experiment_submitted:
-                print(f"\033[92m✅Experiment '{exp_name}' was successfully submitted!\033[0m")
-                return True
-            else:
-                return False
+            #if self.experiment_submitted:
+                #print(f"\033[92m✅Experiment '{exp_name}' was successfully submitted!\033[0m")
+                #return True
+            #else:
+                #return False
         finally:
             self.remove_workspace_archive(archive_path)
 

--- a/openfl/experimental/workflow/runtime/federated_runtime.py
+++ b/openfl/experimental/workflow/runtime/federated_runtime.py
@@ -162,9 +162,10 @@ class FederatedRuntime(Runtime):
         Args:
             archive_path (str): Archive file path containing the workspace.
             exp_name (str): The name of the experiment to be submitted.
-        
+
         Returns:
-            bool: True if experiment was accepted or submitted succesfully , False if rejected or not submitted to director
+            bool: True if experiment was accepted or submitted succesfully
+                , False if rejected or not submitted to director
         """
         try:
             response = self._runtime_dir_client.set_new_experiment(
@@ -176,11 +177,7 @@ class FederatedRuntime(Runtime):
                 print(f"\033[92m✅Experiment '{exp_name}' was successfully submitted!\033[0m")
                 return True
             else:
-                #print(f"\033[91m ?Experiment '{exp_name}' submission was rejected by the Director\033[0m")
                 return False
-                #raise RuntimeError(
-                    #f"Failed to submit experiment '{exp_name}' to the director. Rejected by director."
-                #)
         finally:
             self.remove_workspace_archive(archive_path)
 

--- a/openfl/experimental/workflow/transport/grpc/director_client.py
+++ b/openfl/experimental/workflow/transport/grpc/director_client.py
@@ -98,21 +98,26 @@ class EnvoyDirectorClient:
         response = self.stub.EnvoyConnectionRequest(request)
 
         return response.accepted
-    
-    def send_experiment_review(self, envoy_name: str, experiment_name: str, review_status: str) -> bool:
+
+    def send_experiment_review(
+        self, envoy_name: str, experiment_name: str, review_status: str
+    ) -> bool:
         """
         Send a review response to the director.
 
         Args:
-        envoy_name (str): The name of the envoy sending the response.
-        experiment_name (str): The name of the experiment being reviewed.
-        review_status (str): The review status ("APPROVE" or "REJECT").
+            envoy_name (str): The name of the envoy sending the response.
+            experiment_name (str): The name of the experiment being reviewed.
+            review_status (str): The review status ("APPROVE" or "REJECT").
 
         Returns:
-        bool: True if the response was successfully sent, False otherwise.
+            bool: True if the response was successfully sent, False otherwise.
         """
-        
-        logger.info(f"Sending review response for experiment '{experiment_name}' from envoy '{envoy_name}' with status '{review_status}'.")
+
+        logger.info(
+            f"Sending review response for experiment '{experiment_name}' from envoy '{envoy_name}' "
+            f"with status '{review_status}'."
+        )
 
         request = director_pb2.SendExperimentReviewRequest(
             envoy_name=envoy_name,
@@ -125,8 +130,6 @@ class EnvoyDirectorClient:
         except grpc.RpcError as rpc_error:
             logger.error(f"Failed to send review response: {rpc_error}")
             return False
-        
-
 
     def wait_experiment(self) -> str:
         """

--- a/openfl/experimental/workflow/transport/grpc/director_client.py
+++ b/openfl/experimental/workflow/transport/grpc/director_client.py
@@ -98,6 +98,35 @@ class EnvoyDirectorClient:
         response = self.stub.EnvoyConnectionRequest(request)
 
         return response.accepted
+    
+    def send_experiment_review(self, envoy_name: str, experiment_name: str, review_status: str) -> bool:
+        """
+        Send a review response to the director.
+
+        Args:
+        envoy_name (str): The name of the envoy sending the response.
+        experiment_name (str): The name of the experiment being reviewed.
+        review_status (str): The review status ("APPROVE" or "REJECT").
+
+        Returns:
+        bool: True if the response was successfully sent, False otherwise.
+        """
+        
+        logger.info(f"Sending review response for experiment '{experiment_name}' from envoy '{envoy_name}' with status '{review_status}'.")
+
+        request = director_pb2.SendExperimentReviewRequest(
+            envoy_name=envoy_name,
+            experiment_name=experiment_name,
+            review_status=review_status,
+        )
+        try:
+            response = self.stub.SendExperimentReview(request)
+            return response.consensus_reached
+        except grpc.RpcError as rpc_error:
+            logger.error(f"Failed to send review response: {rpc_error}")
+            return False
+        
+
 
     def wait_experiment(self) -> str:
         """

--- a/openfl/experimental/workflow/transport/grpc/director_client.py
+++ b/openfl/experimental/workflow/transport/grpc/director_client.py
@@ -291,6 +291,7 @@ class RuntimeDirectorClient:
             name=experiment_name,
             col_names=col_names,
         )
+        logger.info("i am in dir_Clint set_new_experiment")
         resp = self.stub.SetNewExperiment(experiment_info_gen)
         return resp
 

--- a/openfl/experimental/workflow/transport/grpc/director_client.py
+++ b/openfl/experimental/workflow/transport/grpc/director_client.py
@@ -111,7 +111,8 @@ class EnvoyDirectorClient:
             review_status (str): The review status ("APPROVE" or "REJECT").
 
         Returns:
-            bool: True if the response was successfully sent, False otherwise.
+            bool: True if consensus was reached after this review; 
+              False if not or if the request failed.
         """
 
         logger.info(
@@ -291,7 +292,6 @@ class RuntimeDirectorClient:
             name=experiment_name,
             col_names=col_names,
         )
-        logger.info("i am in dir_Clint set_new_experiment")
         resp = self.stub.SetNewExperiment(experiment_info_gen)
         return resp
 

--- a/openfl/experimental/workflow/transport/grpc/director_server.py
+++ b/openfl/experimental/workflow/transport/grpc/director_server.py
@@ -55,6 +55,7 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
         listen_port: int = 50051,
         envoy_health_check_period: int = 0,
         director_config: Optional[Path] = None,
+        review_callback=None,  # Add review_callback parameter
         **kwargs,
     ) -> None:
         """
@@ -78,6 +79,7 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
             listen_port (int, optional): The port to listen on. Defaults to
                 50051.
             director_config (Optional[Path]): Path to director_config file
+            review_callback (Optional[Callable]): Callback function for reviewing experiment plans.
             **kwargs: Additional keyword arguments.
         """
         super().__init__()
@@ -93,6 +95,7 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
             certificate=self.certificate,
             envoy_health_check_period=envoy_health_check_period,
             director_config=director_config,
+            review_callback=review_callback,  # Pass review_callback to Director
             **kwargs,
         )
 
@@ -356,3 +359,35 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
                 await asyncio.sleep(1)
                 continue
             yield director_pb2.GetExperimentStdoutResponse(**stdout_dict)
+
+
+    async def SendExperimentReview(self, request, context):
+        """
+         Handle experiment review result from an envoy.
+
+         Args:
+            request (director_pb2.SendExperimentReviewRequest): Contains:
+               - envoy_name: Name of the envoy sending the review
+               - experiment_name: Name of the experiment being reviewed
+               - review_status: "APPROVE" or "REJECT"
+            context (grpc.ServicerContext): The gRPC context
+        Returns:
+            director_pb2.SendExperimentReviewResponse: Contains consensus_reached status
+
+        """
+        logger.info(f"Received review response from envoy '{request.envoy_name}' for experiment '{request.experiment_name}' with status '{request.review_status}'.")
+        # Process the review response in the Director
+        consensus_reached = self.director.process_review_response(
+            envoy_name=request.envoy_name,
+            experiment_name=request.experiment_name,
+            review_status=request.review_status,
+        )
+        # Create a response message
+        response = director_pb2.SendExperimentReviewResponse()
+        response.consensus_reached = consensus_reached
+        if consensus_reached:
+            logger.info(f"Consensus reached for experiment '{request.experiment_name}'.")
+        else:
+            logger.info(f"Consensus not reached for experiment '{request.experiment_name}'.")
+        return response
+

--- a/openfl/experimental/workflow/transport/grpc/director_server.py
+++ b/openfl/experimental/workflow/transport/grpc/director_server.py
@@ -377,7 +377,7 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
         """
         logger.info(f"Received review response from envoy '{request.envoy_name}' for experiment '{request.experiment_name}' with status '{request.review_status}'.")
         # Process the review response in the Director
-        consensus_reached = self.director.process_review_response(
+        consensus_reached = await self.director.process_review_response(
             envoy_name=request.envoy_name,
             experiment_name=request.experiment_name,
             review_status=request.review_status,

--- a/openfl/experimental/workflow/transport/grpc/director_server.py
+++ b/openfl/experimental/workflow/transport/grpc/director_server.py
@@ -361,7 +361,6 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
                 continue
             yield director_pb2.GetExperimentStdoutResponse(**stdout_dict)
 
-
     async def SendExperimentReview(self, request, context):
         """
          Handle experiment review result from an envoy.
@@ -372,23 +371,20 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
                - experiment_name: Name of the experiment being reviewed
                - review_status: "APPROVE" or "REJECT"
             context (grpc.ServicerContext): The gRPC context
+
         Returns:
             director_pb2.SendExperimentReviewResponse: Contains consensus_reached status
 
         """
-        logger.info(f"Received review response from envoy '{request.envoy_name}' for experiment '{request.experiment_name}' with status '{request.review_status}'.")
-        # Process the review response in the Director
+        logger.info(
+            f"Received review response from envoy '{request.envoy_name}' for "
+            f"experiment '{request.experiment_name}' with status '{request.review_status}'."
+        )
         consensus_reached = await self.director.process_review_response(
             envoy_name=request.envoy_name,
             experiment_name=request.experiment_name,
             review_status=request.review_status,
         )
-        # Create a response message
         response = director_pb2.SendExperimentReviewResponse()
         response.consensus_reached = consensus_reached
-        #if consensus_reached:
-            #logger.info(f"Consensus reached for experiment '{request.experiment_name}'.")
-        #else:
-            #logger.info(f"Consensus not reached for experiment '{request.experiment_name}'.")
         return response
-

--- a/openfl/experimental/workflow/transport/grpc/director_server.py
+++ b/openfl/experimental/workflow/transport/grpc/director_server.py
@@ -315,16 +315,15 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
         )
         # Build response with review statuses
         review_entries = self.director.experiments_registry[request.name].review_details
-        review_statuses = []
-        for reviewer_name, entries in review_entries.items():
-            for entry in entries:
-                review_statuses.append(
-                    director_pb2.ExperimentReviewStatus(
-                        reviewer=entry['reviewer_name'],
-                        decision=entry['decision'],
-                        timestamp=entry['timestamp']
-                    )
-                )
+        review_statuses = [
+            director_pb2.ExperimentReviewStatus(
+                reviewer=entry['reviewer_name'],
+                decision=entry['decision'],
+                timestamp=entry['timestamp']
+            )
+            for entries in review_entries.values()
+            for entry in entries
+        ]
         if not is_accepted:
             return director_pb2.SetNewExperimentResponse(
                 status=is_accepted, 

--- a/openfl/experimental/workflow/transport/grpc/director_server.py
+++ b/openfl/experimental/workflow/transport/grpc/director_server.py
@@ -313,10 +313,29 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
             collaborator_names=request.collaborator_names,
             experiment_archive_path=data_file_path,
         )
+        # Build response with review statuses
+        review_entries = self.director.experiments_registry[request.name].review_details
+        review_statuses = []
+        for reviewer_name, entries in review_entries.items():
+            for entry in entries:
+                review_statuses.append(
+                    director_pb2.ExperimentReviewStatus(
+                        reviewer=entry['reviewer_name'],
+                        decision=entry['decision'],
+                        timestamp=entry['timestamp']
+                    )
+                )
         if not is_accepted:
-            return director_pb2.SetNewExperimentResponse(status=is_accepted)
+            return director_pb2.SetNewExperimentResponse(
+                status=is_accepted, 
+                review_statuses=review_statuses
+            )
         logger.info("Experiment %s registered", request.name)
-        return director_pb2.SetNewExperimentResponse(status=is_accepted)
+        return director_pb2.SetNewExperimentResponse(
+            status=is_accepted,
+            review_statuses=review_statuses
+        )
+        
 
     async def GetFlowState(self, request, context) -> director_pb2.GetFlowStateResponse:
         """Get updated flow after experiment is finished.

--- a/openfl/experimental/workflow/transport/grpc/director_server.py
+++ b/openfl/experimental/workflow/transport/grpc/director_server.py
@@ -313,7 +313,8 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
             collaborator_names=request.collaborator_names,
             experiment_archive_path=data_file_path,
         )
-
+        if not is_accepted:
+            return director_pb2.SetNewExperimentResponse(status=is_accepted)
         logger.info("Experiment %s registered", request.name)
         return director_pb2.SetNewExperimentResponse(status=is_accepted)
 
@@ -385,9 +386,9 @@ class DirectorGRPCServer(director_pb2_grpc.DirectorServicer):
         # Create a response message
         response = director_pb2.SendExperimentReviewResponse()
         response.consensus_reached = consensus_reached
-        if consensus_reached:
-            logger.info(f"Consensus reached for experiment '{request.experiment_name}'.")
-        else:
-            logger.info(f"Consensus not reached for experiment '{request.experiment_name}'.")
+        #if consensus_reached:
+            #logger.info(f"Consensus reached for experiment '{request.experiment_name}'.")
+        #else:
+            #logger.info(f"Consensus not reached for experiment '{request.experiment_name}'.")
         return response
 


### PR DESCRIPTION
## SUMMARY

This proposal introduces a structured mechanism for reviewing and agreeing on plans for executing FL experiments in `FederatedRuntime` within the Workflow API.  
This feature enables all participants, including the Director and Envoys, to review and approve an experiment plan before execution.

The Director, acting as the orchestrator, manages this review process to ensure consistency, trust, and readiness across the federation.  
Additionally, the User/Data Scientist who submitted the experiment plan will be notified of the outcome (approval or rejection) on completion of the review process.


## MOTIVATION

Currently in `FederatedRuntime`, users can initiate and execute Federated Machine Learning experiments without explicit approval from all participants (including Directors or Envoys).  
While this approach allows for a swift action, the absence of formal agreement or review process may lead to the following challenges:

- **Trust Concerns**: Directors and Envoy admins, as owners of sensitive data, may seek greater control and insights regarding the experiments being conducted.  
  A formal review process is highly desirable for owners of sensitive data, allowing them to review the plan and enhance trust.

- **Risk of Execution Failures**: If an Envoy is unprepared or disagrees with the proposed plan, it can result in execution failures.  
  A structured agreement process can help ensure readiness and consensus among all parties involved.

## SCOPE

- This proposal is applicable only for the `FederatedRuntime`.
- The scenario to dynamically add envoys to an ongoing experiment is out of scope of the current design.
- Support for a configurable review policy that allows the user to control the outcome of the review process is not included in the current proposal.  
  The current design is flexible and can be extended in the future if this feature is needed.

---

## KEY REQUIREMENTS

### Feature Configuration

- Each participant in the Federation shall be able to configure this feature individually.  
  The feature can be enabled or disabled by including an optional `review_experiment` flag in each participant's configuration (YAML) file.  
  The behavior of `review_experiment` in each participant's configuration file shall be as follows:
  
  - `review_experiment: false` → plan is auto-approved
  - `review_experiment: true` → node-admin review and approval is required

- **Default**: If the `review_experiment` setting is not present in the configuration, the participant defaults to manually approving the experiment  
  (i.e., as if `review_experiment: true`).
  
  - This ensures stricter control over experiment execution in case this setting has been overlooked by the node admin.

## CONFIGURATION FILE INTERFACE

- To enable the plan review workflow, node-admin shall set the `review_experiment` flag to `true` in the configuration file as shown below:

```yaml
settings:
  listen_host: localhost
  listen_port: 50050
  envoy_health_check_period: 5  # in seconds
  review_experiment: True
```
**PERSISTENCE OF CONFIGURATION**

- Configuration is read by the participant at startup and applies to all the experiments conducted after the node is started.  
  Changes to the configuration require a participant node to be restarted.

**DIRECTOR AND ENVOY INTERFACE FOR REVIEWING AND APPROVING THE PLAN**

- If the `review_experiment` flag is enabled, the plan for the received experiment shall be printed on the console and the following interface will be presented to the Director and Envoys for reviewing and responding to the experiment plan.

<img width="390" height="290" alt="image" src="https://github.com/user-attachments/assets/ba764923-8573-48b5-9ccf-87bed7ea450d" />

**REVIEW TIMELINE**

- If the `review_experiment` flag is set to `true`, Director and Envoy shall wait for manual approval (or rejection) of the plan.


 **NOTIFY PLAN REVIEW OUTCOME TO USER/DATA SCIENTIST**

- On completion of the review process, the User shall be provided a notification including:
  - Outcome of the review: **Accepted / Rejected**
  - Individual participants' approval/rejection status including timestamps (e.g., outcome as shown below)

<img width="638" height="73" alt="image" src="https://github.com/user-attachments/assets/5e13f2ca-189b-4a2a-ae9a-d363f4d7a264" />

**EXPERIMENT EXECUTION ON CONSENSUS**

- The experiment shall only be executed when all participants have reviewed and accepted the plan.


**PROPOSED APPROACH**
The mechanism consists of two phases: **Review Phase** and **Execution Phase**.

### Phase 1: Review Phase

#### Director Review
- Director reviews the plan.
  - If the Director rejects the plan: The experiment is aborted immediately, and the User is notified of the outcome (**Rejected**) along with the Director's review status and timestamp.
  - If the Director approves the plan: The experiment is forwarded to all authorized Envoys for further review.

#### Envoy Review
- Each Envoy receives the experiment plan for review and provides their response to the Director.

#### Director Consensus
- Director waits for responses from all Envoys:
  - If **all Envoys approve**: The User is notified that the experiment was approved, including timestamps of responses by the Director and all Envoys. The experiment moves to the execution phase.
  - If **any Envoy rejects**: The User is notified that the plan was rejected, including timestamps of responses by the Director and all Envoys. The experiment is aborted, and cleanup is triggered on all participants.

### Phase 2: Execution Phase

If the Director and all Envoys approve the experiment:

- Director starts the **Aggregator**.
- All Envoys are notified to run the **Collaborator**.

---

## SCENARIOS

### Scenario A: Director rejects the plan
<img width="1034" height="362" alt="image" src="https://github.com/user-attachments/assets/e72b9f2a-20ed-4556-9351-727d52acfd04" />

### Scenario B: Director approves the plan and (any) Envoy rejects the plan
<img width="1114" height="842" alt="image" src="https://github.com/user-attachments/assets/e4c2e30e-c1ec-4fd3-acc6-adcd9ee09294" />

### Scenario C: ALL participants approve the plan
<img width="1045" height="762" alt="image" src="https://github.com/user-attachments/assets/5699e40a-9af9-49ce-9764-0253f6f04676" />

## RISKS AND MITIGATION

Different combinations of participant approvals and rejections shall be validated thoroughly to ensure that an experiment proceeds only when all participants have approved the plan.

---

## VALIDATION

Manual

---

## DEMONSTRATION

Feature shall be demonstrated by modifying the existing  
`openfl-tutorials/experimental/workflow/FederatedRuntime/101_MNIST` tutorial.